### PR TITLE
fix: exclude app-template Helm chart from automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,11 @@
       "matchUpdateTypes": ["patch", "digest", "pin"],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "description": "Never automerge app-template Helm chart updates",
+      "matchPackageNames": ["app-template"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
The `app-template` Helm chart is used across nearly all apps. Updates to it can be breaking and should always be reviewed manually.

Adds a `packageRules` entry that overrides the Tier 1/2 automerge rules for `app-template`.