### PR TITLE
fix: disable platformAutomerge for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,7 @@
   "git-submodules": {
     "enabled": true
   },
+  "platformAutomerge": false,
   "packageRules": [
     {
       "description": "Tier 1: Automerge patch + minor for low-risk apps and infra",


### PR DESCRIPTION
The `main` branch has no branch protection rules, so GitHub's native auto-merge API (`platformAutomerge: true` from `config:best-practices`) silently fails.

Setting `platformAutomerge: false` tells Renovate to merge PRs directly itself, which doesn't require branch protection.

After merging, Renovate should start automerging qualifying PRs on its next run.