### PR TITLE
fix: correct action SHA pins in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run yamllint
-        uses: ibiqlik/action-yamllint@2576378a8e339169c23c544b2e01f7744e55f089 # v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3
         with:
           config_file: .yamllint.yaml
           file_or_dir: kubernetes/ ansible/


### PR DESCRIPTION
The `ibiqlik/action-yamllint` SHA was invalid (truncated/incorrect), causing all CI runs to fail.

Fixes:
- `actions/checkout`: updated to v6.0.2 (`de0fac2e`)
- `ibiqlik/action-yamllint`: corrected to v3.1.1 (`2576378a`)