### PR TITLE
fix: resolve all yamllint warnings for strict mode

### DIFF
--- a/ansible/playbooks/setup.yaml
+++ b/ansible/playbooks/setup.yaml
@@ -1,3 +1,4 @@
+---
 - name: Run Proxmox PVE setup playbook
   ansible.builtin.import_playbook: proxmox_pve/setup.yaml
 

--- a/ansible/playbooks/utilities/hardreset-talos-cluster-vms.yaml
+++ b/ansible/playbooks/utilities/hardreset-talos-cluster-vms.yaml
@@ -17,7 +17,7 @@
       - 110
       - 111
       - 112
-    disk_size: "32" # in GB
+    disk_size: "32"  # in GB
     storage: "workloads"
     disk_options: "iothread=1"
     dry_run: false  # Set to true for dry-run mode

--- a/ansible/roles/proxmox_pve/tasks/setup/setup_fence_provider.yaml
+++ b/ansible/roles/proxmox_pve/tasks/setup/setup_fence_provider.yaml
@@ -1,3 +1,4 @@
+---
 - name: Install HA Fence Watchdog
   when: pve_ha_fence_provider == 'idrac'
   block:

--- a/ansible/sample_inventory/bind9.yaml
+++ b/ansible/sample_inventory/bind9.yaml
@@ -1,3 +1,4 @@
+---
 bind9:
   children:
     bind9_main:

--- a/ansible/sample_inventory/group_vars/bind9.yaml
+++ b/ansible/sample_inventory/group_vars/bind9.yaml
@@ -1,3 +1,4 @@
+---
 manage_firewall: no
 
 keys:

--- a/ansible/sample_inventory/host_vars/dns-01.local.example.com.yaml
+++ b/ansible/sample_inventory/host_vars/dns-01.local.example.com.yaml
@@ -1,3 +1,4 @@
+---
 master_zones:
   local.example.com:
     transfer_groups:
@@ -5,5 +6,5 @@ master_zones:
   ad.example.com:
     transfer_groups:
       - dns_02
-    update_groups: # an example of how Windows Active Directory can be configured to use a BIND9 server
+    update_groups:  # an example of how Windows Active Directory can be configured to use a BIND9 server
       - winad

--- a/ansible/sample_inventory/host_vars/dns-02.local.example.com.yaml
+++ b/ansible/sample_inventory/host_vars/dns-02.local.example.com.yaml
@@ -1,3 +1,4 @@
+---
 slave_zones:
   local.example.com:
     master_groups:

--- a/ansible/sample_inventory/proxmox.yaml
+++ b/ansible/sample_inventory/proxmox.yaml
@@ -1,3 +1,4 @@
+---
 proxmox:
   children:
     pve:

--- a/kubernetes/apps/cross-seed/secret-generator.yaml
+++ b/kubernetes/apps/cross-seed/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/idrac-fan-control/secret-generator.yaml
+++ b/kubernetes/apps/idrac-fan-control/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/kometa/config/config.yml
+++ b/kubernetes/apps/kometa/config/config.yml
@@ -22,10 +22,10 @@ libraries:
         template_variables:
           rating1: user
           rating1_image: imdb
-          #rating2: audience
-          #rating2_image: rt_popcorn
-          #rating3: critic
-          #rating3_image: rt_tomato
+          # rating2: audience
+          # rating2_image: rt_popcorn
+          # rating3: critic
+          # rating3_image: rt_tomato
 
           horizontal_position: left
           vertical_position: bottom
@@ -69,10 +69,10 @@ libraries:
         template_variables:
           rating1: user
           rating1_image: imdb
-          #rating2: audience
-          #rating2_image: rt_popcorn
-          #rating3: critic
-          #rating3_image: rt_tomato
+          # rating2: audience
+          # rating2_image: rt_popcorn
+          # rating3: critic
+          # rating3_image: rt_tomato
 
           horizontal_position: left
           vertical_position: bottom

--- a/kubernetes/apps/kometa/secret-generator.yaml
+++ b/kubernetes/apps/kometa/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/mosquitto/secret-generator.yaml
+++ b/kubernetes/apps/mosquitto/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/n8n/secret-generator.yaml
+++ b/kubernetes/apps/n8n/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/paperless/secret-generator.yaml
+++ b/kubernetes/apps/paperless/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/plex-auto-languages/secret-generator.yaml
+++ b/kubernetes/apps/plex-auto-languages/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/qbittorrent/secret-generator.yaml
+++ b/kubernetes/apps/qbittorrent/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/apps/recyclarr/config/recyclarr.yml
+++ b/kubernetes/apps/recyclarr/config/recyclarr.yml
@@ -27,50 +27,50 @@ radarr:
       # Audio
       - trash_ids:
           # Uncomment the next section to enable Advanced Audio Formats
-          # - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          # - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          # - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          # - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          # - 3cafb66171b47f226146a0770576870f # TrueHD
-          # - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          # - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          # - e7c2fcae07cbada050a0af3357491d7b # PCM
-          # - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          # - 185f1dd7264c4562b9022d963ac37424 # DD+
-          # - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          # - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          # - 240770601cc226190c367ef59aba7463 # AAC
-          # - c2998bd0d90ed5621d8df281e839436e # DD
+          # - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          # - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          # - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          # - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          # - 3cafb66171b47f226146a0770576870f  # TrueHD
+          # - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          # - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          # - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          # - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          # - 185f1dd7264c4562b9022d963ac37424  # DD+
+          # - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          # - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          # - 240770601cc226190c367ef59aba7463  # AAC
+          # - c2998bd0d90ed5621d8df281e839436e  # DD
         assign_scores_to:
           - name: UHD Bluray + WEB
 
       # Movie Versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
         assign_scores_to:
           - name: UHD Bluray + WEB
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
+            # score: 0  # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Optional
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
-          - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
+          - b17886cb4158d9fea189859409975758  # HDR10Plus Boost
         assign_scores_to:
           - name: UHD Bluray + WEB
 
       - trash_ids:
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
         assign_scores_to:
           - name: UHD Bluray + WEB
-            # score: 0 # Uncomment this line to allow SDR releases
+            # score: 0  # Uncomment this line to allow SDR releases
 
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
         assign_scores_to:
           - name: HD Bluray + WEB
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
+            # score: 0  # Uncomment this line to disable prioritised IMAX Enhanced releases
 
 sonarr:
   tv:
@@ -101,56 +101,56 @@ sonarr:
       # HDR Formats
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+          - 9b27ab6498ec0f31a3353992e19434ca  # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
-          - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10Plus Boost
+          - 0dad0a507451acddd754fe6dc3a7f5e7  # HDR10Plus Boost
         assign_scores_to:
           - name: WEB-2160p
 
       # Optional
       - trash_ids:
-          - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
-          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
-          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
-          - 06d66ab109d4d2eddb2794d21526d140 # Retags
-          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
+          - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+          - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+          - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+          - 06d66ab109d4d2eddb2794d21526d140  # Retags
+          - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         assign_scores_to:
           - name: WEB-2160p
 
       - trash_ids:
           # Uncomment the next six lines to allow x265 HD releases with HDR/DV
-          # - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
+          # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
         # assign_scores_to:
           # - name: WEB-2160p
             # score: 0
       # - trash_ids:
-          # - 9b64dff695c2115facf1b6ea59c9bd07 # x265 (no HDR/DV)
+          # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         assign_scores_to:
           - name: WEB-2160p
 
       - trash_ids:
-          - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
+          - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
         assign_scores_to:
           - name: WEB-2160p
-            # score: 0 # Uncomment this line to enable SDR releases
+            # score: 0  # Uncomment this line to enable SDR releases
 
       # Optional
       - trash_ids:
-          - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
-          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
-          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
-          - 06d66ab109d4d2eddb2794d21526d140 # Retags
-          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
+          - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+          - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+          - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+          - 06d66ab109d4d2eddb2794d21526d140  # Retags
+          - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         assign_scores_to:
           - name: WEB-1080p
 
       - trash_ids:
           # Uncomment the next six lines to allow x265 HD releases with HDR/DV
-          # - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
+          # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
         # assign_scores_to:
           # - name: WEB-1080p
             # score: 0
       # - trash_ids:
-          # - 9b64dff695c2115facf1b6ea59c9bd07 # x265 (no HDR/DV)
+          # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         assign_scores_to:
           - name: WEB-1080p

--- a/kubernetes/apps/recyclarr/secret-generator.yaml
+++ b/kubernetes/apps/recyclarr/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/bootstrap/cilium/app.yaml
+++ b/kubernetes/bootstrap/cilium/app.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+
+spec:
+  project: default
+  source:
+    repoURL: https://helm.cilium.io/
+    chart: cilium
+    targetRevision: 1.17.1
+
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: kube-system
+    syncPolicy:
+      syncOptions:
+        - CreateNamespace=true
+      managedNamespaceMetadata:
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+      automated:
+        selfHeal: true
+        prune: true
+
+    helm:
+      valuesObject:
+        ipam:
+          mode: kubernetes
+
+        kubeProxyReplacement: true
+
+        securityContext:
+          capabilities:
+            ciliumAgent:
+              - CHOWN
+              - KILL
+              - NET_ADMIN
+              - NET_RAW
+              - IPC_LOCK
+              - SYS_ADMIN
+              - SYS_RESOURCE
+              - DAC_OVERRIDE
+              - FOWNER
+              - SETGID
+              - SETUID
+            cleanCiliumState:
+              - NET_ADMIN
+              - SYS_ADMIN
+              - SYS_RESOURCE
+
+        cgroup:
+          autoMount:
+            enabled: false
+          hostRoot: /sys/fs/cgroup
+
+        k8sServiceHost: localhost
+        k8sServicePort: 7445
+
+        bgpControlPlane:
+          enabled: true
+
+        gatewayAPI:
+          enabled: true
+          enableAlpn: true
+          enableAppProtocol: true
+
+        ingressController:
+          enabled: true
+          loadbalancerMode: dedicated
+          default: true
+
+        hubble:
+          enabled: true
+          relay:
+            enabled: true
+          ui:
+            enabled: true

--- a/kubernetes/infra/alertmanager/secret-generator.yaml
+++ b/kubernetes/infra/alertmanager/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/infra/cert-manager/secret-generator.yaml
+++ b/kubernetes/infra/cert-manager/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/infra/prometheus-operator/app.yaml
+++ b/kubernetes/infra/prometheus-operator/app.yaml
@@ -193,7 +193,7 @@ spec:
             podMonitorSelectorNilUsesHelmValues: false
             probeSelectorNilUsesHelmValues: false
             replicas: 1
-            replicaExternalLabelName: "__replica__" # must match with thanos value `.query.replicaLabel[0]`
+            replicaExternalLabelName: "__replica__"  # must match with thanos value `.query.replicaLabel[0]`
             resources:
               requests:
                 cpu: 100m
@@ -203,7 +203,7 @@ spec:
             retentionSize: 50GB
             ruleSelectorNilUsesHelmValues: false
             scrapeConfigSelectorNilUsesHelmValues: false
-            scrapeInterval: 1m # Must match interval in Grafana Helm chart
+            scrapeInterval: 1m  # Must match interval in Grafana Helm chart
             serviceMonitorSelectorNilUsesHelmValues: false
             storageSpec:
               volumeClaimTemplate:

--- a/kubernetes/infra/secret-generator.yaml
+++ b/kubernetes/infra/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/infra/tailscale-operator/secret-generator.yaml
+++ b/kubernetes/infra/tailscale-operator/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:

--- a/kubernetes/infra/velero/app.yaml
+++ b/kubernetes/infra/velero/app.yaml
@@ -84,7 +84,7 @@ spec:
               config:
                 region: us-west-001
                 s3Url: "https://s3.us-west-001.backblazeb2.com"
-                checksumAlgorithm: "" # required for Backblaze B2
+                checksumAlgorithm: ""  # required for Backblaze B2
 
           volumeSnapshotLocation:
             - name: democratic-csi
@@ -97,7 +97,7 @@ spec:
         schedules:
           daily-backups:
             disabled: false
-            schedule: "0 1 * * *" # once a day, at midnight
+            schedule: "0 1 * * *"  # once a day, at midnight
             useOwnerReferencesInBackup: false
             template:
               ttl: "240h"

--- a/kubernetes/infra/velero/secret-generator.yaml
+++ b/kubernetes/infra/velero/secret-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:


### PR DESCRIPTION
CI was failing because `strict: true` treats warnings as errors.

Fixes:
- Add missing `---` document start markers to 26 files
- Fix inline comment spacing (2 spaces before `#`) in 5 files
- Add space after `#` in commented-out lines in kometa config

`yamllint --strict` now passes with zero warnings and zero errors.