### PR TITLE
fix: replace ibiqlik/action-yamllint with native yamllint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,12 @@
+---
 name: CI
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - "kubernetes/**/*.yaml"
-      - "kubernetes/**/*.yml"
-      - "ansible/**/*.yaml"
-      - "ansible/**/*.yml"
+      - "**/*.yaml"
+      - "**/*.yml"
       - ".yamllint.yaml"
       - ".github/workflows/ci.yaml"
 
@@ -19,11 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7
 
       - name: Run yamllint
-        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3
-        with:
-          config_file: .yamllint.yaml
-          file_or_dir: kubernetes/ ansible/
-          strict: true
+        run: uvx yamllint --strict --format github -c .yamllint.yaml .

--- a/.github/workflows/update-xseed.yaml
+++ b/.github/workflows/update-xseed.yaml
@@ -1,3 +1,4 @@
+---
 name: Sync xseed.sh from Gist
 
 on:
@@ -18,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,10 +36,10 @@ jobs:
       - name: Create or update branch
         run: |
           echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
-          
+
           # Stash any uncommitted changes first
           git stash -u
-          
+
           # Check if branch exists remotely
           if git ls-remote --heads origin ${{ env.BRANCH_NAME }} | grep -q ${{ env.BRANCH_NAME }}; then
             echo "Branch ${{ env.BRANCH_NAME }} exists remotely, updating..."
@@ -48,19 +49,19 @@ jobs:
             echo "Creating new branch ${{ env.BRANCH_NAME }}..."
             git checkout -b ${{ env.BRANCH_NAME }}
           fi
-          
+
           # Apply stashed files if any were stashed
           git stash list | grep -q "stash@{0}" && git stash pop || echo "No stashed changes"
-        
+
       - name: Check if file changed and commit
         id: check_changes
         run: |
           # Make sure directory exists
           mkdir -p kubernetes/apps/custom-arrscripts/scripts/
-          
+
           # Copy the new file
           cp gist/${{ env.GIST_FILE }} ${{ env.FILE_PATH }}.new
-          
+
           # Check if file exists first
           if [ -f ${{ env.FILE_PATH }} ]; then
             # Compare files
@@ -69,11 +70,11 @@ jobs:
               echo "changed=true" >> $GITHUB_OUTPUT
               mv ${{ env.FILE_PATH }}.new ${{ env.FILE_PATH }}
               chmod ${{ env.FILE_PERMISSION }} ${{ env.FILE_PATH }}
-              
+
               # Add changes and commit
               git add ${{ env.FILE_PATH }}
               git commit -m "chore(deps): Update ${{ env.GIST_FILE }} from Gist"
-              
+
               # Push changes with explicit upstream setting
               git push --set-upstream origin ${{ env.BRANCH_NAME }}
             else
@@ -85,11 +86,11 @@ jobs:
             echo "File does not exist yet - creating"
             echo "changed=true" >> $GITHUB_OUTPUT
             mv ${{ env.FILE_PATH }}.new ${{ env.FILE_PATH }}
-            
+
             # Add changes and commit
             git add ${{ env.FILE_PATH }}
             git commit -m "chore(deps): Add ${{ env.GIST_FILE }} from Gist"
-            
+
             # Push changes with explicit upstream setting
             git push --set-upstream origin ${{ env.BRANCH_NAME }}
           fi
@@ -101,7 +102,7 @@ jobs:
         run: |
           # Check if PR already exists
           PR_EXISTS=$(gh pr list --head "${{ env.BRANCH_NAME }}" --base "${{ env.BASE_BRANCH }}" --state open --json number | grep -c '"number":' || true)
-          
+
           if [ "$PR_EXISTS" -gt 0 ]; then
             echo "PR already exists, updated branch."
           else

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,7 +7,7 @@ rules:
   # Helm templates and SOPS files may have unconventional formatting
   comments-indentation: disable
   truthy:
-    allowed-values: ["true", "false", "yes", "no"]
+    allowed-values: ["true", "false", "yes", "no", "on"]
 
 ignore:
   # SOPS-encrypted files contain binary data that won't lint cleanly


### PR DESCRIPTION
Replaces the stale `ibiqlik/action-yamllint` (last updated Oct 2022) with native `yamllint` via `uvx`, as [recommended by the yamllint docs](https://yamllint.readthedocs.io/en/latest/integration.html).

### Changes
- Use `uvx yamllint` (single step, no install needed, uses pre-installed `uv` on GitHub runners)
- Lint entire repo (`.`) instead of specific folders — new directories automatically covered
- Add `on` to truthy allowed-values for GitHub Actions `on:` key
- Fix lint issues in workflow files (document start, trailing spaces, comment spacing)