### PR TITLE
feat: label non-automerge Renovate PRs with manual-review

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,6 +67,16 @@
       "description": "Never automerge app-template Helm chart updates",
       "matchPackageNames": ["app-template"],
       "automerge": false
+    },
+    {
+      "description": "Label PRs that require manual review",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["manual-review"]
+    },
+    {
+      "description": "Label non-automerge PRs for manual review",
+      "automerge": false,
+      "addLabels": ["manual-review"]
     }
   ]
 }


### PR DESCRIPTION
Adds `manual-review` label to Renovate PRs that need manual intervention:
- All major updates
- All PRs where automerge is disabled (packages not in tier 1/2 lists)