### PR TITLE
fix: remove invalid Renovate packageRule causing config error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,16 +66,12 @@
     {
       "description": "Never automerge app-template Helm chart updates",
       "matchPackageNames": ["app-template"],
-      "automerge": false
-    },
-    {
-      "description": "Label PRs that require manual review",
-      "matchUpdateTypes": ["major"],
+      "automerge": false,
       "addLabels": ["manual-review"]
     },
     {
-      "description": "Label non-automerge PRs for manual review",
-      "automerge": false,
+      "description": "Label major updates for manual review",
+      "matchUpdateTypes": ["major"],
       "addLabels": ["manual-review"]
     }
   ]


### PR DESCRIPTION
Fixes Renovate config error (issue #354).

The rule `{"automerge": false, "addLabels": ["manual-review"]}` had no `match*` field, so Renovate treated it as "disable automerge for ALL packages".

Fix: add `manual-review` label directly on the app-template rule and keep a separate rule for major updates only.