### PR TITLE
feat: group Velero and plugins into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,6 +78,11 @@
       "automerge": true,
       "automergeType": "pr",
       "labels": []
+    },
+    {
+      "description": "Group Velero and its plugins into a single PR",
+      "matchFileNames": ["kubernetes/infra/velero/**"],
+      "groupName": "velero"
     }
   ]
 }


### PR DESCRIPTION
Groups all packages under `kubernetes/infra/velero/` (Velero helm chart + velero-plugin-for-aws) into a single PR since they need to be updated together.