### PR TITLE
feat: group kube-prometheus-stack and CRDs into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,11 @@
       "description": "Group Velero and its plugins into a single PR",
       "matchFileNames": ["kubernetes/infra/velero/**"],
       "groupName": "velero"
+    },
+    {
+      "description": "Group kube-prometheus-stack and its CRDs into a single PR",
+      "matchFileNames": ["kubernetes/infra/prometheus-operator/**"],
+      "groupName": "kube-prometheus-stack"
     }
   ]
 }


### PR DESCRIPTION
Groups `prometheus-operator-crds` and `kube-prometheus-stack` (both in `kubernetes/infra/prometheus-operator/`) into a single PR since they need to be updated together.