### PR TITLE
fix: use labels instead of addLabels for manual-review

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,8 +22,12 @@
   "git-submodules": {
     "enabled": true
   },
-  "addLabels": ["manual-review"],
   "packageRules": [
+    {
+      "description": "Default: label all PRs for manual review",
+      "matchUpdateTypes": ["major", "minor", "patch", "digest", "pin", "rollback", "bump"],
+      "labels": ["manual-review"]
+    },
     {
       "description": "Tier 1: Automerge patch + minor for low-risk apps and infra",
       "matchFileNames": [


### PR DESCRIPTION
Fixes automerge PRs (like #350) incorrectly getting the `manual-review` label.

The top-level `addLabels` is always additive and cannot be overridden by `labels: []` in packageRules. Replaced with a catch-all first packageRule using `labels: ["manual-review"]`, which later automerge rules override with `labels: []`.