### PR TITLE
fix: allow 1-space before inline comments in yamllint

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,6 +5,8 @@ rules:
   # Long lines are common in Kubernetes manifests (URLs, annotations, etc.)
   line-length: disable
   # Helm templates and SOPS files may have unconventional formatting
+  comments:
+    min-spaces-from-content: 1
   comments-indentation: disable
   truthy:
     allowed-values: ["true", "false", "yes", "no", "on"]


### PR DESCRIPTION
Renovate's GitHub Actions digest pinning produces lines like:
```yaml
uses: actions/checkout@SHA # v6
```
with only 1 space before the comment. The default yamllint `comments` rule requires 2 spaces, causing CI failures on Renovate PRs (e.g. #372).

This sets `min-spaces-from-content: 1` for the `comments` rule so both 1-space and 2-space comments are accepted.