### PR TITLE
fix: add pinDigest to Renovate rules and schedule automerge at 0530 UTC

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
     "config:best-practices",
     ":disableRateLimiting"
   ],
+  "timezone": "Asia/Jerusalem",
+  "automergeSchedule": ["after 5:30am and before 6:00am"],
   "argocd": {
     "managerFilePatterns": [
       "/^kubernetes/.+\\.ya?ml$/"
@@ -31,7 +33,7 @@
     },
     {
       "description": "Default: label all PRs for manual review",
-      "matchUpdateTypes": ["major", "minor", "patch", "digest", "pin", "rollback", "bump"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest", "pin", "pinDigest", "rollback", "bump"],
       "labels": ["manual-review"]
     },
     {
@@ -60,7 +62,7 @@
         "kubernetes/infra/prometheus-operator/**",
         "kubernetes/infra/tailscale-operator/**"
       ],
-      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
       "automerge": true,
       "automergeType": "pr",
       "labels": []
@@ -71,7 +73,7 @@
         "kubernetes/apps/mosquitto/**",
         "kubernetes/apps/paperless/**"
       ],
-      "matchUpdateTypes": ["patch", "digest", "pin"],
+      "matchUpdateTypes": ["patch", "digest", "pin", "pinDigest"],
       "automerge": true,
       "automergeType": "pr",
       "labels": []
@@ -84,7 +86,7 @@
     {
       "description": "Automerge GitHub Actions digest updates",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["digest", "pin", "patch", "minor"],
+      "matchUpdateTypes": ["digest", "pin", "pinDigest", "patch", "minor"],
       "automerge": true,
       "automergeType": "pr",
       "labels": []


### PR DESCRIPTION
## Problem

PRs #367 and #371 are not being auto-merged by Renovate **and** lack the `manual-review` label.

Both contain `pinDigest` updates (adding `@sha256:...` to existing tags). In Renovate, `pinDigest` is a **distinct update type** — it is not covered by `pin` or `digest` in `matchUpdateTypes`.

Since `pinDigest` was missing from every rule in `renovate.json`, these PRs fell through completely: no automerge, no label.

## Changes

- Add `pinDigest` to all four `matchUpdateTypes` arrays (default labeling, Tier 1, Tier 2, GitHub Actions)
- Add `automergeSchedule` to restrict automerge to 05:30–06:00 Israel time daily
- Add `timezone: Asia/Jerusalem` for schedule interpretation