### PR TITLE
ci: add do-not-merge label check workflow

### DIFF
--- a/.github/workflows/do-not-merge.yaml
+++ b/.github/workflows/do-not-merge.yaml
@@ -1,0 +1,20 @@
+---
+name: Do Not Merge
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  do-not-merge:
+    name: Do Not Merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for do-not-merge label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | jq -e 'map(select(. == "do-not-merge")) | length > 0' > /dev/null; then
+            echo "::error::This PR has the 'do-not-merge' label and cannot be merged."
+            exit 1
+          fi


### PR DESCRIPTION
Add a GitHub Actions workflow that blocks merging PRs carrying the `do-not-merge` label.

- Triggers on `pull_request_target` (labeled/unlabeled/opened/reopened/synchronize)
- Fails with a clear error when the label is present
- No third-party actions — just a shell + jq check

After merging, add **Do Not Merge** as a required status check in the repo ruleset to enforce it as a merge gate.