### PR TITLE
fix: widen automerge schedule from 30min to 5-hour window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":disableRateLimiting"
   ],
   "timezone": "Asia/Jerusalem",
-  "automergeSchedule": ["after 5:30am and before 6:00am"],
+  "automergeSchedule": ["after 2am and before 7am"],
   "argocd": {
     "managerFilePatterns": [
       "/^kubernetes/.+\\.ya?ml$/"


### PR DESCRIPTION
The previous 30-minute window (5:30–6:00 AM) was too narrow for the Renovate GitHub App to reliably run during, causing automerge-eligible PRs to pile up unmerged. Widens to 2:00–7:00 AM Israel time.