### PR TITLE
ci: make SOPS integrity check and Do Not Merge required status checks

### DIFF
--- a/.github/workflows/sops-integrity-check.yaml
+++ b/.github/workflows/sops-integrity-check.yaml
@@ -2,9 +2,7 @@
 name: SOPS Integrity Check
 on:
   pull_request:
-    paths:
-      - "**/*.sops.yaml"
-      - "**/*.sops.yml"
+    branches: [main]
 
 jobs:
   check-sops-mac:
@@ -18,7 +16,7 @@ jobs:
         run: |
           changed_sops=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- '*.sops.yaml' '*.sops.yml')
           if [ -z "$changed_sops" ]; then
-            echo "No SOPS files changed"
+            echo "No SOPS files changed — skipping"
             exit 0
           fi
 


### PR DESCRIPTION
Remove the `paths:` filter from the SOPS integrity check workflow so it runs on **all PRs**, not just those touching `.sops.yaml` files. When no SOPS files are changed, the check exits successfully with a skip message.

This enables `check-sops-mac` to be used as a required status check without blocking non-SOPS PRs.