### PR TITLE
fix: migrate recyclarr config to v8 format

### DIFF
--- a/kubernetes/apps/recyclarr/config/recyclarr.yml
+++ b/kubernetes/apps/recyclarr/config/recyclarr.yml
@@ -1,11 +1,15 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ---
+################################################################################
+## Radarr: UHD Bluray + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#uhd-bluray-web
+################################################################################
 radarr:
-  movies:
+  uhd-bluray-web:
     base_url: !secret radarr_url
     api_key: !secret radarr_apikey
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
 
     media_naming:
       folder: plex-tmdb
@@ -13,71 +17,75 @@ radarr:
         rename: true
         standard: plex-tmdb
 
-    include:
-      # Comment out any of the following includes to disable them
-      - template: radarr-quality-definition-movie
-      - template: radarr-quality-profile-uhd-bluray-web
-      - template: radarr-custom-formats-uhd-bluray-web
-      - template: radarr-quality-definition-movie
-      - template: radarr-quality-profile-hd-bluray-web
-      - template: radarr-custom-formats-hd-bluray-web
+    quality_definition:
+      type: movie
 
-    # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-    custom_formats:
-      # Audio
-      - trash_ids:
-          # Uncomment the next section to enable Advanced Audio Formats
-          # - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
-          # - 2f22d89048b01681dde8afe203bf2e95  # DTS X
-          # - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
-          # - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
-          # - 3cafb66171b47f226146a0770576870f  # TrueHD
-          # - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
-          # - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
-          # - e7c2fcae07cbada050a0af3357491d7b  # PCM
-          # - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
-          # - 185f1dd7264c4562b9022d963ac37424  # DD+
-          # - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
-          # - 1c1a4c5e823891c75bc50380a6866f73  # DTS
-          # - 240770601cc226190c367ef59aba7463  # AAC
-          # - c2998bd0d90ed5621d8df281e839436e  # DD
-        assign_scores_to:
-          - name: UHD Bluray + WEB
+    quality_profiles:
+      - trash_id: 64fb5f9858489bdac2af690e27c8f42f  # UHD Bluray + WEB
+        name: UHD Bluray + WEB
+        reset_unmatched_scores:
+          enabled: true
 
-      # Movie Versions
-      - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        assign_scores_to:
-          - name: UHD Bluray + WEB
-            # score: 0  # Uncomment this line to disable prioritised IMAX Enhanced releases
+    custom_format_groups:
+      add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+        - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+          select:
+            - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+          select:
+            - 9c38ebb7384dada637be8899efa68e6f  # SDR
+            # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
 
-      # Optional
-      - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
-          # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
-          - b17886cb4158d9fea189859409975758  # HDR10Plus Boost
-        assign_scores_to:
-          - name: UHD Bluray + WEB
+  ################################################################################
+  ## Radarr: HD Bluray + WEB
+  ##
+  ## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#hd-bluray-web
+  ################################################################################
+  hd-bluray-web:
+    base_url: !secret radarr_url
+    api_key: !secret radarr_apikey
+    delete_old_custom_formats: true
 
-      - trash_ids:
-          - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        assign_scores_to:
-          - name: UHD Bluray + WEB
-            # score: 0  # Uncomment this line to allow SDR releases
+    media_naming:
+      folder: plex-tmdb
+      movie:
+        rename: true
+        standard: plex-tmdb
 
-      - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        assign_scores_to:
-          - name: HD Bluray + WEB
-            # score: 0  # Uncomment this line to disable prioritised IMAX Enhanced releases
+    quality_definition:
+      type: movie
 
+    quality_profiles:
+      - trash_id: d1d67249d3890e49bc12e275d989a7e9  # HD Bluray + WEB
+        name: HD Bluray + WEB
+        reset_unmatched_scores:
+          enabled: true
+
+    custom_format_groups:
+      add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+          select:
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+          select:
+            - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+
+################################################################################
+## Sonarr: WEB-2160p
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p
+################################################################################
 sonarr:
-  tv:
+  web-2160p:
     base_url: !secret sonarr_url
     api_key: !secret sonarr_apikey
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
 
     media_naming:
       series: plex-tvdb
@@ -88,69 +96,72 @@ sonarr:
         daily: default
         anime: default
 
-    include:
-      # Comment out any of the following includes to disable them
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
-      - template: sonarr-v4-custom-formats-web-1080p
-      - template: sonarr-v4-quality-profile-web-2160p
-      - template: sonarr-v4-custom-formats-web-2160p
+    quality_definition:
+      type: series
 
-    # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-    custom_formats:
-      # HDR Formats
-      - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 9b27ab6498ec0f31a3353992e19434ca  # DV (WEBDL)
-          # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
-          - 0dad0a507451acddd754fe6dc3a7f5e7  # HDR10Plus Boost
-        assign_scores_to:
-          - name: WEB-2160p
+    quality_profiles:
+      - trash_id: d1498e7d189fbe6c7110ceaabb7473e6  # WEB-2160p
+        name: WEB-2160p
+        reset_unmatched_scores:
+          enabled: true
 
-      # Optional
-      - trash_ids:
-          - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-          - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
-          - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
-          - 06d66ab109d4d2eddb2794d21526d140  # Retags
-          - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-        assign_scores_to:
-          - name: WEB-2160p
+    custom_format_groups:
+      add:
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
+        - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+          select:
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+          select:
+            - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+            # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
 
-      - trash_ids:
-          # Uncomment the next six lines to allow x265 HD releases with HDR/DV
-          # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-        # assign_scores_to:
-          # - name: WEB-2160p
-            # score: 0
-      # - trash_ids:
-          # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        assign_scores_to:
-          - name: WEB-2160p
+  ################################################################################
+  ## Sonarr: WEB-1080p
+  ##
+  ## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p
+  ################################################################################
+  web-1080p:
+    base_url: !secret sonarr_url
+    api_key: !secret sonarr_apikey
+    delete_old_custom_formats: true
 
-      - trash_ids:
-          - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        assign_scores_to:
-          - name: WEB-2160p
-            # score: 0  # Uncomment this line to enable SDR releases
+    media_naming:
+      series: plex-tvdb
+      season: default
+      episodes:
+        rename: true
+        standard: default
+        daily: default
+        anime: default
 
-      # Optional
-      - trash_ids:
-          - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-          - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
-          - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
-          - 06d66ab109d4d2eddb2794d21526d140  # Retags
-          - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-        assign_scores_to:
-          - name: WEB-1080p
+    quality_definition:
+      type: series
 
-      - trash_ids:
-          # Uncomment the next six lines to allow x265 HD releases with HDR/DV
-          # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-        # assign_scores_to:
-          # - name: WEB-1080p
-            # score: 0
-      # - trash_ids:
-          # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        assign_scores_to:
-          - name: WEB-1080p
+    quality_profiles:
+      - trash_id: 72dae194fc92bf828f32cde7744e51a1  # WEB-1080p
+        name: WEB-1080p
+        reset_unmatched_scores:
+          enabled: true
+
+    custom_format_groups:
+      add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+          select:
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 1b3994c551cbb92a2c781af061f4ab44  # Scene


### PR DESCRIPTION
## Summary

Recyclarr v8.0 (auto-updated by Renovate in `846a303`) introduced breaking changes that broke the daily CronJob. This PR migrates the config to the v8 format.

### Changes

- **Removed** `replace_existing_custom_formats: true` (deleted in v8)
- **Removed** all `include: - template:` directives (templates removed from v8 config-templates)
- **Replaced** with guide-backed `quality_profiles` using `trash_id` and `custom_format_groups`
- **Split** single Radarr/Sonarr instances into per-profile instances (v8 convention):
  - `radarr/uhd-bluray-web` — UHD Bluray + WEB (`64fb5f9…`)
  - `radarr/hd-bluray-web` — HD Bluray + WEB (`d1d6724…`)
  - `sonarr/web-2160p` — WEB-2160p (`d1498e7…`)
  - `sonarr/web-1080p` — WEB-1080p (`72dae19…`)
- **Updated** schema URL to `schemas.recyclarr.dev/v8/config-schema.json`
- **Included `name:`** on all profiles for adoption of existing Radarr/Sonarr profiles

### Customizations Preserved

All active customizations mapped 1:1 to v8 custom_format_groups:
- HDR10+ Boost (UHD/2160p profiles)
- IMAX Enhanced (both Radarr profiles)
- SDR penalties (UHD/2160p profiles)
- Miscellaneous CFs: Bad Dual Groups, No-RlsGroup, Obfuscated, Retags, Scene (Sonarr profiles)

### Post-Merge

After the first successful `recyclarr sync`, the `name:` fields can optionally be removed to let the TRaSH Guide names take effect.