### PR TITLE
chore: remove recyclarr profile name overrides and redundant selects

### DIFF
--- a/kubernetes/apps/recyclarr/config/recyclarr.yml
+++ b/kubernetes/apps/recyclarr/config/recyclarr.yml
@@ -17,24 +17,16 @@ radarr:
 
     quality_profiles:
       - trash_id: 64fb5f9858489bdac2af690e27c8f42f  # UHD Bluray + WEB
-        name: UHD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
       - trash_id: d1d67249d3890e49bc12e275d989a7e9  # HD Bluray + WEB
-        name: HD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
 
     custom_format_groups:
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
-          select:
-            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
-          select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
         - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
           select:
@@ -64,24 +56,16 @@ sonarr:
 
     quality_profiles:
       - trash_id: d1498e7d189fbe6c7110ceaabb7473e6  # WEB-2160p
-        name: WEB-2160p
         reset_unmatched_scores:
           enabled: true
       - trash_id: 72dae194fc92bf828f32cde7744e51a1  # WEB-1080p
-        name: WEB-1080p
         reset_unmatched_scores:
           enabled: true
 
     custom_format_groups:
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
-          select:
-            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
-          select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
           select:


### PR DESCRIPTION
## Summary

Follow-up to the v8 migration. Now that profiles have been adopted after a successful sync:

### Changes
- **Remove `name:` fields** from all 4 quality profiles — profiles are now tracked by `trash_id` in Recyclarr's state, so the name override is no longer needed. Guide names will take effect on next sync.
- **Remove redundant `select:` entries** from Golden Rule groups — the CFs (x265 HD, x265 no HDR/DV) are defaults in their respective groups and don't need explicit selection.

### Verification

The adoption sync completed successfully with all ✓:

| | Custom Formats | Quality Profiles | Quality Sizes | Media Naming |
|---|---|---|---|---|
| **movies** | ✓ (20) | ✓ (2) | ✓ | -- |
| **tv** | ✓ (7) | ✓ (2) | ✓ | ✓ |