### PR TITLE
feat: add stirling-pdf deployment

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - radarr/app.yaml
   - recyclarr/app.yaml
   - rotki/app.yaml
+  - stirling-pdf/app.yaml
   - sabnzbd/app.yaml
   - sonarr/app.yaml
   - tautulli/app.yaml

--- a/kubernetes/apps/stirling-pdf/app.yaml
+++ b/kubernetes/apps/stirling-pdf/app.yaml
@@ -1,0 +1,170 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stirling-pdf-configs
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+
+spec:
+  project: default
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: selfhosted
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/enforce: privileged
+    automated:
+      selfHeal: true
+      prune: true
+
+  source:
+    repoURL: https://github.com/mpeterson/homelab
+    path: kubernetes/apps/stirling-pdf/
+    targetRevision: main
+
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/common-3.7.3/charts/library/common/values.schema.json
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: &app stirling-pdf
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+
+spec:
+  project: default
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: selfhosted
+
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/enforce: privileged
+    automated:
+      selfHeal: true
+      prune: true
+
+  source:
+    repoURL: https://bjw-s-labs.github.io/helm-charts
+    chart: app-template
+    targetRevision: 4.6.2
+    helm:
+      valuesObject:
+        strategy: RollingUpdate
+
+        controllers:
+          stirling-pdf:
+            replicas: 1
+            pod:
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                fsGroup: 1000
+                fsGroupChangePolicy: "OnRootMismatch"
+
+            containers:
+              app:
+                image:
+                  repository: ghcr.io/stirling-tools/s-pdf
+                  tag: latest-fat
+                env:
+                  DOCKER_ENABLE_SECURITY: "true"
+                  SECURITY_ENABLELOGIN: "true"
+                  SECURITY_INITIALLOGIN_USERNAME:
+                    valueFrom:
+                      secretKeyRef:
+                        name: stirling-pdf-secret
+                        key: SECURITY_INITIALLOGIN_USERNAME
+                  SECURITY_INITIALLOGIN_PASSWORD:
+                    valueFrom:
+                      secretKeyRef:
+                        name: stirling-pdf-secret
+                        key: SECURITY_INITIALLOGIN_PASSWORD
+                  SYSTEM_DEFAULTLOCALE: en_US
+                  SYSTEM_MAXFILESIZE: "2000"
+                probes:
+                  liveness:
+                    enabled: true
+                  readiness:
+                    enabled: true
+                  startup:
+                    enabled: true
+                    spec:
+                      failureThreshold: 30
+                      periodSeconds: 5
+                resources:
+                  requests:
+                    cpu: 25m
+                    memory: 512Mi
+                  limits:
+                    memory: 4Gi
+
+        service:
+          app:
+            controller: *app
+            ports:
+              http:
+                port: &port 8080
+
+        route:
+          app:
+            enabled: true
+            kind: HTTPRoute
+            hostnames:
+              - pdf.peterson.com.ar
+            parentRefs:
+              - kind: Gateway
+                name: public-gateway
+                namespace: network
+                sectionName: https
+            rules:
+              - backendRefs:
+                  - name: stirling-pdf
+                    port: *port
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+
+        persistence:
+          configs:
+            storageClass: zfs-generic-iscsi-csi-xfs
+            accessMode: ReadWriteOnce
+            size: 500Mi
+            globalMounts:
+              - path: /configs
+          tessdata:
+            storageClass: zfs-generic-iscsi-csi-xfs
+            accessMode: ReadWriteOnce
+            size: 1Gi
+            globalMounts:
+              - path: /usr/share/tessdata
+          logs:
+            storageClass: zfs-generic-iscsi-csi-xfs
+            accessMode: ReadWriteOnce
+            size: 500Mi
+            globalMounts:
+              - path: /logs
+          pipeline:
+            storageClass: zfs-generic-iscsi-csi-xfs
+            accessMode: ReadWriteOnce
+            size: 1Gi
+            globalMounts:
+              - path: /pipeline
+          tmp:
+            type: emptyDir
+            globalMounts:
+              - path: /tmp

--- a/kubernetes/apps/stirling-pdf/kustomization.yaml
+++ b/kubernetes/apps/stirling-pdf/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+  - secret-generator.yaml

--- a/kubernetes/apps/stirling-pdf/secret-generator.yaml
+++ b/kubernetes/apps/stirling-pdf/secret-generator.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./secret.sops.yaml

--- a/kubernetes/apps/stirling-pdf/secret.sops.yaml
+++ b/kubernetes/apps/stirling-pdf/secret.sops.yaml
@@ -1,0 +1,24 @@
+kind: Secret
+apiVersion: v1
+type: Opaque
+metadata:
+    name: stirling-pdf-secret
+    namespace: selfhosted
+stringData:
+    SECURITY_INITIALLOGIN_USERNAME: ENC[AES256_GCM,data:Fit1NQ6xjS9u,iv:t7/1KmRSt641KtycXIXgtgXTsv83mvRaCf49OgBRX8E=,tag:wundRGu/IYkUoF7bTXI1Ew==,type:str]
+    SECURITY_INITIALLOGIN_PASSWORD: ENC[AES256_GCM,data:77ll6sY9t7rXNILoxBdwxY0X8I8t/z9oNg==,iv:qS5bE8KHY4Dban7FXita5HRSMr1Lwe7VdfqPuC7gfi4=,tag:or2jTdmoHixyQTe6lP/Grw==,type:str]
+sops:
+    age:
+        - recipient: age1v6dnmkex8qstz8wrp3as58ap8yecvp5gttt67hktepc7s9kluvvsz94664
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzUU84d2RJYmIrSVNCZ3lo
+            b2pHRVBhcUNKcURwTWpmRnVFejZ1TElFb1gwCk5nU2pGa2hJNkJPWWk0QVhzVEV1
+            L1ZlVllVOTJGUGRwazZWNjRQR1J2a3MKLS0tIHV3UFV5bElUUjI3T1ByQkVMWm1k
+            YzZQV0JaOXU0Y0FtNUNuLzdWYmhqeTQKnR33k3DwwCVSePETk0pKF4ZtQalHpmR3
+            4cxUmHE9wUDJK7CqWNa1lAQjrTIZcmniq4zPTt25mem9u0zNkn6IJw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-03-17T09:32:10Z"
+    mac: ENC[AES256_GCM,data:GUN65Q+gKsw/0Jewr5j7MrUjVUiHy51Vy36Wyv2dFCKG6CZYP+hNCY8p+J5ASqvFclUYwaA1wFnKipCo38/WjOIdD7YMjnOf2g8d40g4TvOe1eU14ejMQNj/xAnm9zK1l+v98mnMGIs+NNERRDYAfnebruORtX/fToW9m2eahBU=,iv:IEx37hozKIHEfq0rIRqh4wJ53HTYOmL7aYve/N4WCus=,tag:TudFjztmgvgld9mqO4a/Bg==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type|project|destination|syncPolicy|repoURL|chart|targetRevision)$
+    version: 3.12.1


### PR DESCRIPTION
## Summary

Deploy [Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF)

### Configuration
- **Image:** `ghcr.io/stirling-tools/s-pdf:latest-fat` (all OCR languages + tools)
- **URL:** `pdf.peterson.com.ar` (public gateway)
- **Namespace:** `selfhosted`

### Persistent Volumes (`zfs-generic-iscsi-csi-xfs`)
| Mount | Size | Purpose |
|-------|------|---------|
| `/configs` | 500Mi | Application settings & user data |
| `/usr/share/tessdata` | 1Gi | OCR language packs |
| `/logs` | 500Mi | Application logs |
| `/pipeline` | 1Gi | Batch processing folders |
| `/tmp` | emptyDir | Temporary files |

### Files
- `kubernetes/apps/stirling-pdf/app.yaml` — ArgoCD Applications (configs + main app)
- `kubernetes/apps/stirling-pdf/kustomization.yaml` — ksops generator
- `kubernetes/apps/stirling-pdf/secret-generator.yaml` — ksops config
- `kubernetes/apps/stirling-pdf/secret.sops.yaml` — Encrypted admin credentials
- `kubernetes/apps/kustomization.yaml` — Added to resources list