### PR TITLE
fix: correct stirling-pdf env var warnings

### DIFF
--- a/kubernetes/apps/stirling-pdf/app.yaml
+++ b/kubernetes/apps/stirling-pdf/app.yaml
@@ -94,8 +94,10 @@ spec:
                       secretKeyRef:
                         name: stirling-pdf-secret
                         key: SECURITY_INITIALLOGIN_PASSWORD
-                  SYSTEM_DEFAULTLOCALE: en_US
-                  SYSTEM_MAXFILESIZE: "2000"
+                  SYSTEM_DEFAULTLOCALE: en-US
+                  SYSTEM_MAXFILESIZE: "999"
+                  SPRINGDOC_API_DOCS_ENABLED: "false"
+                  SPRINGDOC_SWAGGER_UI_ENABLED: "false"
                 probes:
                   liveness:
                     enabled: true


### PR DESCRIPTION
Fixes warnings from stirling-pdf startup logs:

- **`SYSTEM_DEFAULTLOCALE`**: `en_US` → `en-US` (hyphen format required, was falling back to en-GB)
- **`SYSTEM_MAXFILESIZE`**: `2000` → `999` (valid range is 1-999, value was being ignored)
- **Disable SpringDoc/Swagger UI**: public-facing app shouldn't expose API docs