### PR TITLE
feat: add stirling-pdf to renovate Tier 1 automerge

### DIFF
--- a/kubernetes/apps/stirling-pdf/app.yaml
+++ b/kubernetes/apps/stirling-pdf/app.yaml
@@ -77,7 +77,7 @@ spec:
               app:
                 image:
                   repository: ghcr.io/stirling-tools/s-pdf
-                  tag: latest-fat
+                  tag: 2.7.2-fat@sha256:8ebaeb83d1d8c1f6c4d8935ba77cacabdd042aa84bd9b2fb22ff0bd80023cea9
                 env:
                   PUID: "1000"
                   PGID: "1000"

--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,7 @@
         "kubernetes/apps/rotki/**",
         "kubernetes/apps/sabnzbd/**",
         "kubernetes/apps/sonarr/**",
+        "kubernetes/apps/stirling-pdf/**",
         "kubernetes/apps/tautulli/**",
         "kubernetes/infra/alertmanager/**",
         "kubernetes/infra/metrics-server/**",


### PR DESCRIPTION
Adds `kubernetes/apps/stirling-pdf/**` to the Tier 1 automerge rule (minor + patch).