### PR TITLE
fix: enable platformAutomerge and remove unused schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
     ":disableRateLimiting"
   ],
   "timezone": "Asia/Jerusalem",
-  "automergeSchedule": ["after 2am and before 7am"],
   "argocd": {
     "managerFilePatterns": [
       "/^kubernetes/.+\\.ya?ml$/"
@@ -24,7 +23,7 @@
   "git-submodules": {
     "enabled": true
   },
-  "platformAutomerge": false,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "description": "SOPS files: never automerge, label for manual re-encryption",


### PR DESCRIPTION
Switch to GitHub-native auto-merge (`platformAutomerge: true`) so PRs merge in parallel as soon as checks pass, instead of Renovate's serial one-per-run automerge.

Remove `automergeSchedule` since it is [ignored when platformAutomerge is enabled](https://github.com/renovatebot/renovate/issues/21436) — GitHub merges immediately when checks pass regardless of any Renovate schedule.