### PR TITLE
fix: restrict Renovate PR creation to 2-7am window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":disableRateLimiting"
   ],
   "timezone": "Asia/Jerusalem",
+  "schedule": ["after 2am and before 7am"],
   "argocd": {
     "managerFilePatterns": [
       "/^kubernetes/.+\\.ya?ml$/"


### PR DESCRIPTION
Add `schedule` to limit when Renovate creates and updates PRs. With `platformAutomerge` enabled, this effectively controls when merges happen since auto-merge is enabled at PR creation time.