### PR TITLE
feat: add iSCSI session recovery tuning for PCS failover

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,116 @@
+# Homelab management recipes
+
+# List available backups
+velero-backups:
+    velero backup get
+
+# Restore a PVC from a Velero backup using CSI snapshots.
+#
+# This handles the full lifecycle: pausing ArgoCD, scaling down,
+# deleting the old PVC, restoring from backup, scaling back up,
+# and re-enabling ArgoCD.
+#
+# Usage:
+#   just velero-restore-pvc overseerr media overseerr-config velero-daily-backups-20260316010049
+#   just velero-restore-pvc paperless paperless paperless-data velero-daily-backups-20260325010002
+velero-restore-pvc app namespace pvc backup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "==> Pausing ArgoCD reconciliation for '{{app}}'..."
+    kubectl annotate application {{app}} -n argocd \
+      argocd.argoproj.io/skip-reconcile="true" --overwrite
+
+    echo "==> Scaling down '{{app}}' in namespace '{{namespace}}'..."
+    kubectl scale deployment {{app}} -n {{namespace}} --replicas=0
+    kubectl wait --for=delete pod \
+      -l app.kubernetes.io/name={{app}} -n {{namespace}} --timeout=120s || true
+
+    echo "==> Deleting PVC '{{pvc}}'..."
+    kubectl delete pvc {{pvc}} -n {{namespace}} --timeout=60s
+
+    echo "==> Restoring from backup '{{backup}}'..."
+    RESTORE_NAME="{{app}}-{{pvc}}-restore-$(date +%s)"
+    velero restore create "$RESTORE_NAME" \
+      --from-backup {{backup}} \
+      --include-namespaces {{namespace}} \
+      --include-resources persistentvolumeclaims,persistentvolumes,volumesnapshots.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io \
+      --selector "app.kubernetes.io/name={{app}}" \
+      --existing-resource-policy none
+
+    echo "==> Waiting for PVC '{{pvc}}' to bind..."
+    for i in $(seq 1 30); do
+      STATUS=$(kubectl get pvc {{pvc}} -n {{namespace}} -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+      if [ "$STATUS" = "Bound" ]; then
+        echo "    PVC is Bound!"
+        break
+      fi
+      echo "    [$i/30] PVC status: $STATUS"
+      sleep 10
+    done
+
+    if [ "$STATUS" != "Bound" ]; then
+      echo "ERROR: PVC did not bind within 5 minutes. Check events:"
+      kubectl get events -n {{namespace}} \
+        --field-selector involvedObject.name={{pvc}} \
+        --sort-by=.lastTimestamp | tail -5
+      exit 1
+    fi
+
+    echo "==> Scaling up '{{app}}'..."
+    kubectl scale deployment {{app}} -n {{namespace}} --replicas=1
+    kubectl rollout status deployment {{app}} -n {{namespace}} --timeout=120s
+
+    echo "==> Resuming ArgoCD reconciliation for '{{app}}'..."
+    kubectl annotate application {{app}} -n argocd \
+      argocd.argoproj.io/skip-reconcile-
+
+    echo "==> Done! Verify the application is working correctly."
+
+# Check which PVCs are included in a specific Velero backup
+velero-check-backup backup app="":
+    #!/usr/bin/env bash
+    if [ -n "{{app}}" ]; then
+      velero backup describe {{backup}} --details 2>&1 | grep -i "{{app}}"
+    else
+      velero backup describe {{backup}} --details 2>&1 | grep -E "Operation for|Operation ID"
+    fi
+
+# Pause ArgoCD reconciliation for an application
+argocd-pause app:
+    kubectl annotate application {{app}} -n argocd \
+      argocd.argoproj.io/skip-reconcile="true" --overwrite
+    @echo "ArgoCD reconciliation paused for '{{app}}'"
+
+# Resume ArgoCD reconciliation for an application
+argocd-resume app:
+    kubectl annotate application {{app}} -n argocd \
+      argocd.argoproj.io/skip-reconcile-
+    @echo "ArgoCD reconciliation resumed for '{{app}}'"
+
+# Restart all deployments that use iSCSI PVCs (e.g., after PCS failover)
+restart-iscsi-pods:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "==> Finding deployments with PersistentVolumeClaims..."
+    PODS=$(kubectl get deploy -A -o json | \
+      jq -r '.items[] | select(.spec.template.spec.volumes[]? | has("persistentVolumeClaim")) | "\(.metadata.namespace) \(.metadata.name)"')
+
+    if [ -z "$PODS" ]; then
+      echo "No deployments with PVCs found."
+      exit 0
+    fi
+
+    echo "$PODS" | while read ns name; do
+      echo "  Restarting $ns/$name..."
+      kubectl rollout restart deployment "$name" -n "$ns"
+    done
+
+    echo "==> Waiting for rollouts to complete..."
+    echo "$PODS" | while read ns name; do
+      kubectl rollout status deployment "$name" -n "$ns" --timeout=120s || \
+        echo "  WARNING: $ns/$name rollout did not complete within 120s"
+    done
+
+    echo "==> Done!"

--- a/kubernetes/infra/democratic-csi/app-iscsi.sops.yaml
+++ b/kubernetes/infra/democratic-csi/app-iscsi.sops.yaml
@@ -28,136 +28,140 @@ spec:
         helm:
             valuesObject:
                 node:
-                    hostPID: ENC[AES256_GCM,data:vrJuqQ==,iv:OvEAO3JfXLCKoEInsP43ZmBqQJZsvtd7TgcL2n0s3vE=,tag:vzs/9TWjrls+Zyj5P9ZM5A==,type:bool]
+                    hostPID: ENC[AES256_GCM,data:Bx62Rg==,iv:ZwXiG+Rp6lZuZXNNj+BKuLkcvMsEIlJ0CGLQCYYwv4E=,tag:P3JGKtQybotnwvicI/3FaQ==,type:bool]
                     driver:
                         extraEnv:
-                            - name: ENC[AES256_GCM,data:W/SvvT63EclgrfE5s8TvXRE5tocS+w==,iv:ydk0mpvIhGTOyOEbuVjp2OGxsuD1y6soBFQiw6f0UKo=,tag:cj3edZH4teiFLXhPtNBZ1w==,type:str]
-                              value: ENC[AES256_GCM,data:aZPQ5pc2yw==,iv:v/Sp31gcnBEQKgknaPg6SRx6vN7Ajd5W1BJ5N82NGnY=,tag:rBUeQfgE/UaM245Sqf3v9g==,type:str]
-                            - name: ENC[AES256_GCM,data:2N9SXOGeR5OWF9/aW5q0edFh,iv:tsiffji8HauQar5JZShw4YkYRE0aO2LAsB2fyfPwu+k=,tag:LJUVEmBfEcuCyr5Uh6OKIQ==,type:str]
-                              value: ENC[AES256_GCM,data:DhxyE8CVMjyq0RFwYdoUJ/pTyG/MWE6A,iv:J6CMXtUN57xGPcIog4Mo2D/HIBeiH6v0wkv9u9A8pa8=,tag:gxxye7YBt0PqY9M+rpbK4w==,type:str]
-                        iscsiDirHostPath: ENC[AES256_GCM,data:k97fxGCZDEbtWQ==,iv:9Mt2khS2BW8V8zQJi8SwL0cQhrsfPqSjinIR5P0tI90=,tag:iswxiWUMgem+OraA2BMs6w==,type:str]
+                            - name: ENC[AES256_GCM,data:ju8+mQXRpOsBCcA6jBU57xiBrahvjg==,iv:nWcVWPtulZD5bkRC3+SpohnfzQK2l4hi/SEO076MbtU=,tag:7faJY7/hdnlbiO0P3qy7LQ==,type:str]
+                              value: ENC[AES256_GCM,data:Tq3jYT0YEQ==,iv:brLb9HhtuxZrUpK9S+eOtyVOBrY6vnQ8+Dtwl9g0Tug=,tag:OsIXZ8hX4zO2VXhX/WuQeg==,type:str]
+                            - name: ENC[AES256_GCM,data:6ZU0NYgaFcAQGhk39GhoXtac,iv:DJbLAk8sdtJ5hb0ZphHOkIyAH/vHaFi4grTwxLMangg=,tag:Allv6GHMXzJ2Vr1C6mQF/A==,type:str]
+                              value: ENC[AES256_GCM,data:/CB/71nwalTs1KJoC9c83335kMR1+0lz,iv:Lt84u4T5je0KG0P4vW+JYFXOGxKaMFNmLY1j98cRrlc=,tag:UyxGhAAognvj/PJZxhXJEw==,type:str]
+                        iscsiDirHostPath: ENC[AES256_GCM,data:P9zmEuuwVVpSeg==,iv:rBBAWxc51a3mmXERoOKVOoVKbxQ+fjN8boZZpbymPNQ=,tag:Q4A5myWV/8iwUabFQB7ZZQ==,type:str]
                         iscsiDirHostPathType: ""
                 csiDriver:
-                    #ENC[AES256_GCM,data:v+rml1sR/1in9czhaE/BWnlC1ebcIQNjdSB1nm614VcXXanzAYqTBhUdbHrHKw==,iv:jNj5ZtwfdxepcxCh/RUOyEODWPnFn4PRbfmcxgH7zpg=,tag:1JC38+JXo3hc2k9HRG0zrw==,type:comment]
-                    name: ENC[AES256_GCM,data:rSOm2K1kkYqSBK6iqHtorllDNTBgegEC,iv:5M4NAoofPEc8MBS0o2z+qNt1LZL2u1Tb9sA/+j6ZHAs=,tag:jWsiKIeuUSvlcJ+TfICROQ==,type:str]
-                #ENC[AES256_GCM,data:sg9JjHTHbQmB3BnDdFOI03NSzsZ0nWzRRKHu3YOCr0c3kcYYEDuzQ1MRR+fYKcnMzb4=,iv:XUg3GQPoygsAdm0BHcQT856cKfA8Uxh80IYCMwOrHrE=,tag:8Ddpi67GAoEwHpONJkRm5g==,type:comment]
+                    #ENC[AES256_GCM,data:V+bjmdebivXO7r1opjciGEJ68n/KJ3zkOkb4jmPUWNxOpud7R6ChYrpvwZcYbg==,iv:68WPm1MxkFwbFmzlyVLViDLvxKm+fj3EdMDTj6NWTLA=,tag:uv3NRj3Ef2oXhjK+/NbRSQ==,type:comment]
+                    name: ENC[AES256_GCM,data:K2bKoEEt3WZVnH74rzNmqqVezsndRGxz,iv:S3ym/p1Jae/SGY4QwRxyahFgtpU6X5ky5AF33c5+8c0=,tag:u/9dbnK3ch23lwoUiYRWDQ==,type:str]
+                #ENC[AES256_GCM,data:C5R6VUtXHwae40J6QHxC1pVA4mT5jx3IhGeeX+9/4DQ4jAfJrdm29d7EbKS6DNZH4mE=,iv:194/PeeW+TEx4/JA1iQaqOOII6zsGwsT3XAL6GLKrTk=,tag:xt6AkE0Za43sCMs1/wzXkQ==,type:comment]
                 storageClasses:
-                    - name: ENC[AES256_GCM,data:pzme4tym38E1w5WEod4vvEiAAgdnXZYOIA==,iv:vtpWBP7f46PwGPx03YQET8pwArxNBjinR2GUZ9xXMks=,tag:HXqjjgbJaG6l2nd4mW2Vww==,type:str]
-                      defaultClass: ENC[AES256_GCM,data:geTXID0=,iv:+TWMjEEvQa0vevZUYdHISV5G1SDx8j2VU4mTyGUHHVo=,tag:3MyLNoChE9bZMKbwmmRNkg==,type:bool]
-                      reclaimPolicy: ENC[AES256_GCM,data:4yNzZ3NP,iv:V2/dAkkCR2GBPytWUsIcW141ZH6p1TSqC/LeIqzn8gI=,tag:6kcPUpS3DsI5TWvTUR0uIQ==,type:str]
-                      volumeBindingMode: ENC[AES256_GCM,data:6p+vZo+yFp8q,iv:ALd8viaRZwe76CmquTeKOLvFtTtX04vM0NVGhKajy20=,tag:8O/mQwPD/KyJ30cJr/FsZg==,type:str]
-                      allowVolumeExpansion: ENC[AES256_GCM,data:7DBq2A==,iv:7GWR+TFZ/iX+SHfa+Hl/JRqjHMuoA01FpHOA7p+Jihk=,tag:GGKafXX2KyXFH/g3yTCWcg==,type:bool]
+                    - name: ENC[AES256_GCM,data:AoCHasFIFPdbaxNsYBpSICAGhq2o3VWswg==,iv:1BcbNw3BY6v7K1xFWQYyJvwd5Qw6vHzsO1YBXPESQkg=,tag:gh8UxednXmPJCY4dkAW97g==,type:str]
+                      defaultClass: ENC[AES256_GCM,data:wVVMvig=,iv:yOXnYXfnjXb/wnDIphpMqB69x0PCxfT+1W3sruRt/xU=,tag:L1mGJfXZ6TZX106bHnRU4w==,type:bool]
+                      reclaimPolicy: ENC[AES256_GCM,data:4SKS4obh,iv:0TZlUqmy2Q2jcssuYHcULRNSUII1S0/5lPjJmdgQQHU=,tag:VqMgkngHXBJeFhcGGJe4Bg==,type:str]
+                      volumeBindingMode: ENC[AES256_GCM,data:Sc22Uf3yylUS,iv:QYkkxk6D/KD4wg3GVXNOSYw/77fdHN34FZWc0dLvsh0=,tag:pQwbpxFVHaumdy3pESnjAA==,type:str]
+                      allowVolumeExpansion: ENC[AES256_GCM,data:VLyrUQ==,iv:tSl0qolmHUOYBLJpu+8EgcUmWgIkD5noYaFPCoBNyjc=,tag:O2IuaGTHV2R4RZ1HW3ueLw==,type:bool]
                       parameters:
-                        #ENC[AES256_GCM,data:GcT2Zxr75aLcREcvPJP4LrMiKPURnmTLyWyHs1lLzHvMfI1XRi4MxvreTkdBk/k=,iv:fcYGBPPmK1jn4h0I49+AIlBLfoMXtCPZsqJjiIOvxS4=,tag:RD8vQMeoGEv+ZzEPbJxM1g==,type:comment]
-                        #ENC[AES256_GCM,data:Q4FM0Mjskckd8K7+EBdB2G3BvdTalg==,iv:XN7SO0NkU6xxHttOLh5oL1VO7M9brWnmE7BGxVEaI6A=,tag:cRArlAKyRZHeRHttnqwGxg==,type:comment]
-                        fsType: ENC[AES256_GCM,data:Riqm,iv:nyTejYAYvt0S8ej69LRt6stoJA76UT/ZseM4Z7Nu3hs=,tag:fJFDdhmN1TDqKdd2CDRm+w==,type:str]
-                        #ENC[AES256_GCM,data:5t5MpIpEe/cHAbmwRkud1wgayEs9yfWa6V4hJAOOQ9nCFL+o/DgNvHJIvJgWJ5J2wVYwcxfx,iv:NFjPDq4j4ZE7IUAu3sYiYvT5D4T0DtDPV2gguMyfJi8=,tag:QY5ta4PIbvqkVcT4f/QHoA==,type:comment]
-                        #ENC[AES256_GCM,data:qy1htEGuYat2J24RncYgWNKEoxr27sKtJaxPG7//0y/p3VNkud4abw==,iv:jRlQKJ4UC3w0VC9XuvJeLHTdqQJ+awOGpdmZzJ6Duis=,tag:9HQZClE2dYgFcpvEMC+CuQ==,type:comment]
-                        #ENC[AES256_GCM,data:KP/0XAAz/gcsFcha3W/BuTnrPQMWbeu8NvKzT4CIh5C5YQd5Nn8=,iv:6blo1cOmJ0tMkvcxS19v9vW7Y8hNR40G6KnAPRryUrQ=,tag:XWeZfogTkV1bf8/Z8aIKUA==,type:comment]
-                        #ENC[AES256_GCM,data:6mC8dHJCZPcuaoffvtnQ2QqkIOo4cnC+pXIBEObgQUQ3RyQpC1Gqx+9Sd54WnfJcui44tQ==,iv:sSmaADaO+q6bkKGGqsxM84w5ekqPXNC1glCgxS3cIm8=,tag:tBDk/VScYDk6VfEMRZIEsA==,type:comment]
-                        #ENC[AES256_GCM,data:qy1htEGuYat2J24RncYgWNKEoxr27sKtJaxPG7//0y/p3VNkud4abw==,iv:jRlQKJ4UC3w0VC9XuvJeLHTdqQJ+awOGpdmZzJ6Duis=,tag:9HQZClE2dYgFcpvEMC+CuQ==,type:comment]
-                        #ENC[AES256_GCM,data:Sovf4MpB+N2UFY04W3oZjq+SjIBortwBMdei6nDR885XdiC1,iv:F/ClofnRvAzLJ1xy3iLvAg0x3ssn7sL1IXahapHwaP8=,tag:f0txtEt05VmCNP+3gsMrJw==,type:comment]
+                        #ENC[AES256_GCM,data:v/OSMTQLXiFB4ojmzRjQqg/nSjpdo0DCDYvuYNUweLy5w7N+F0B6dOcgZq2IHGY=,iv:YyCG5DanW4NPNiR1K9n8QXe8osmipk1VkTCajIyqvLA=,tag:nbjDdZjq9LasrkiJ1/1t7g==,type:comment]
+                        #ENC[AES256_GCM,data:OOnr6n/8DH5WSfvJR5FZPVH4SZcQ1g==,iv:K9G1YqINx2cJI0CgWKLDDmnO5YxKIBNUMrwiWhOX3Tw=,tag:D8QJnOpyLL2Dqcp+eiLaVw==,type:comment]
+                        fsType: ENC[AES256_GCM,data:Hrep,iv:Z1m93qaf9R1s/1f+Icup5EmHo2P6a9SeSVA+zl9Z+v0=,tag:lR8/vfZ5KvRiwntderz46g==,type:str]
+                        #ENC[AES256_GCM,data:32N2oCkYK987cHcjFaWYXpcYoPZFuAOJftT0Ts9e7CCfAWb7h34DAasg0GxX5Lt9gsUYm/o+,iv:B+HgeG3QE+IE56arPApxtMST8NfOKrXOq7pgtXgYfbA=,tag:zZVkST8y0JuxmQfMw5gWpg==,type:comment]
+                        #ENC[AES256_GCM,data:bYtuQVdDsy0hbWdE9TAej3+EKH2EcAwocEvHzBvrbSIffCMt5C2X5g==,iv:/uHiBY6aKcS7bj31IWZjvIofDNOY9xkfrbtuoVtPJAE=,tag:39Smcq5Xq/mYoHhQiUPNOw==,type:comment]
+                        #ENC[AES256_GCM,data:E6T+v0bAxQ7iiKbY7ZuUDOHQ9pmnpa36cUuRZ/DXXk2m8SkAQ2g=,iv:xj9h+VjI+mDGKuEO21rix7U9BLrxHx1tMeBGE9mfaM4=,tag:bhfmRvusYSLfjsSGdhk3HA==,type:comment]
+                        #ENC[AES256_GCM,data:PD7tbWBqAiOU2YClfp2Up8fQUQPCUNY10RZzsoFIseoxoS+12z6bjgppJYVC3iH9koMNGw==,iv:WY6HGYGXEkxxkX4C9trb2T0jyiTyjC3oijJczQcyAyM=,tag:yUsggMi47UV/TkNLmy8h1w==,type:comment]
+                        #ENC[AES256_GCM,data:JaKsN3rpxD/P4izePI+aTZgRhrb7UVJ3oOjpH7i3BnLSkThHmXP/Wg==,iv:zcLeiWEVmn8zwd8uTQJcKQ89Pm0IR/F/IxZeJBvDLMI=,tag:Qk+S4rUzKhkEngnxYB2rKw==,type:comment]
+                        #ENC[AES256_GCM,data:6khQ7V6OsgtibA7W+ieK91blsSw9thDN0qtdmjxGTh7DGxHk,iv:F1rCZ3XZc4kUjlYJqNkjL6vX3oipTrlgv8AMYkMEA1g=,tag:DfHMT4LoHdKrRW8v8EVJqw==,type:comment]
                       mountOptions: []
                       secrets:
                         provisioner-secret: null
                         controller-publish-secret: null
                         node-stage-secret:
-                            #ENC[AES256_GCM,data:TY0Oii4ZzbHcKVhRiG1DEmHlyhnrVNLpiXxh9KrWVJevP9pvBzA1Vd9X6RciDwzPPVVHtq4NAWhMZmHlfutanL2ghdSd2jDyYbxF7SN7wxMaU4h5kXxyCXKcNKL1igygfIQT7T4=,iv:ekfrzYlCHhHwm9jNaPskCY4ebCzNf/1rzC0hAr/JfTs=,tag:lqkIp/73BVK+zZPIomFi1Q==,type:comment]
-                            #ENC[AES256_GCM,data:hMIn2O4kRtmHEh2iEV2qg4qz1hZ1,iv:VkfFSnUP79Jzib9cmq7lbMZExiO+UQIq7BBmCLESkuw=,tag:OEvax36YJ+rGx2FVAWzehg==,type:comment]
-                            node-db.node.session.auth.authmethod: ENC[AES256_GCM,data:Q2/Qog==,iv:5y5faCVVQwMQ25Lb3SdRyN6EDf9BVZ9rPWgU47VgUAg=,tag:NFyGG29EI1Bdqm6S7ZvJmw==,type:str]
-                            node-db.node.session.auth.username: ENC[AES256_GCM,data:cI/6CS4RooX4L59AEIw=,iv:7xfhheyaeLk2B5ZQwJo1oYsBbP5PXe3YGo1dIX9/I2E=,tag:FH2HZUeKfuvG/Yk7t9AUwg==,type:str]
-                            node-db.node.session.auth.password: ENC[AES256_GCM,data:XYi3e3PrLQRy2eFcxNE=,iv:D26Q7L9AlKoc3q6IoJIIR4zo1/gqO1i5PjPPkcDIhVo=,tag:YWboZLF+s+MVP1kBCSfqtg==,type:str]
+                            #ENC[AES256_GCM,data:V3e7I9G/okFCpCn0JhlrNDFQQdkq5UbSm4/f+42hyZv9M31OkVT2Ap3ZZxDjaTDunKMaYccLBteYeHbdo0lvEgmqwd6HfWoLwRg6DTaJgqkajwHqvV7YQmRZFyKxtr+8vEZUfgc=,iv:vgPwoDkmiWB9UYm3bHbGUguj/YUdoXWFGZn778C9ffI=,tag:UNPXyyWimNzEjaz840HcrQ==,type:comment]
+                            #ENC[AES256_GCM,data:Mj3TH7OsvLmww43MB4cwd+czUZ/5,iv:Db935FVvVj0SQnG+z8H6EEArLCCfIIW+4u04R62NC0Q=,tag:Ej9hlXBStXl5o62sJ8gTzg==,type:comment]
+                            node-db.node.session.auth.authmethod: ENC[AES256_GCM,data:2iTl5w==,iv:O6jXCMFFr8BtpB3rfoh6Fnt91Lpm259kPt/Vqch3jSo=,tag:4v+AZV3hlasQjPYYqyq2+w==,type:str]
+                            node-db.node.session.auth.username: ENC[AES256_GCM,data:5FafIwpvsf2V42p09MM=,iv:JwibtyDxbfjaqImPeR6nuaxN6vezzm6gentKTBZucpQ=,tag:3BCulFA3Q7sva49bdnOsEw==,type:str]
+                            node-db.node.session.auth.password: ENC[AES256_GCM,data:syXIAy6W7L/B2gVVNFc=,iv:VXczegN876dsx6ATEp4xmWD/CU+pYmjrQjmkh34yx/M=,tag:KK2euUd2U01H2CRgowCgZQ==,type:str]
+                            #ENC[AES256_GCM,data:A0qnLWcAUAPqlLAtXqnjy1RRqYSdKQdIJtLyyiiIMhG8zphku3tz8Us7sBh3AaI=,iv:Fs2+NuHW1VN5sCMyr8ztufWaWZprlbvg08p60+8UyoA=,tag:HSIvognyK8ts/OOB92TEMw==,type:comment]
+                            node-db.node.session.timeo.replacement_timeout: ENC[AES256_GCM,data:TJKk,iv:io+GN9oSfZKLMscV9w/Tj+o2Kp32lpAFrnW5Ngd3QBE=,tag:0razpH6TGPVywhmv8szg+g==,type:str]
                         #
-                        #ENC[AES256_GCM,data:x27jpC20sEqj6JtW5eTuD2s5kEqPfyp70pExcg==,iv:+AV1gDpAAu9Q8kqCcu72lTntEbQe8Ue7DEgO9NZl6mw=,tag:KSyyK0yfPCdbhuqOh93ghQ==,type:comment]
-                        #ENC[AES256_GCM,data:sEyoks+gRlaJ6dS1K+oGr+EjOY7uDZcXWVXzVJ/ljiBZizGlGD78Qw37LOw7/N9W,iv:TNOA+TStaBNOctUWhhpdYhi/qYSgi9YzDNAj4uD/LUs=,tag:bqJ02/+eo6qCvcUGVGuTkg==,type:comment]
-                        #ENC[AES256_GCM,data:MMtixtau+9kMxH7ttV5uxBGYYBZVNYFsn0mBRlBf1/iGzTpLnrlZwSy5aQRvGBfQ,iv:+nIr0F1rp/YsTtlLVG5m+CWNgDLLnzfyp9h4CldvxZQ=,tag:a0rrSv32T2hgJaIk/I2bYw==,type:comment]
+                        #ENC[AES256_GCM,data:BoT7qwNC2sjLS8K4WsWCmtTqEjRWpukytr+PQg==,iv:k0C9FGB6MTPjRs30qtUXCRVU8OtRs+AaxhKD5DAAObM=,tag:4JAn7PHk6xK8RCs8wMO3sw==,type:comment]
+                        #ENC[AES256_GCM,data:2dMsbb8SFoN6zWTbcxJaO0M7ACv5jMgAn6HPerGE4ucxqF26g8r7LT8afED5gtsq,iv:8wrOn4z6BhAwcAX9vHa8UNN2j0tcxCh+DfelkoRE/uY=,tag:wO2Lg7yQcufD+hXi5/+2Mw==,type:comment]
+                        #ENC[AES256_GCM,data:LiYv/hJXk1L/lOxjNilhDysTuLF4Vkz00gTodrxqleCmEWQrmmIQXtj0CfnFRbsc,iv:QNIY+feOPefOVtDEMPRHCVolMLiPcjRHYFsMiJTOtOM=,tag:VcPhKlAF9+lsgBKouOJ5hg==,type:comment]
                         node-publish-secret: null
                         controller-expand-secret: null
-                    - name: ENC[AES256_GCM,data:hErwvltxubbFt1FhK2XKLmgQ2dI30tfkgNc=,iv:SXggZT5t4u4jDfyNkMbQLWzzhq5gXbBIw3NgRRmg1Do=,tag:7bPrmqCmHFb0vyRaSfTz8Q==,type:str]
-                      defaultClass: ENC[AES256_GCM,data:geTXID0=,iv:+TWMjEEvQa0vevZUYdHISV5G1SDx8j2VU4mTyGUHHVo=,tag:3MyLNoChE9bZMKbwmmRNkg==,type:bool]
-                      reclaimPolicy: ENC[AES256_GCM,data:4yNzZ3NP,iv:V2/dAkkCR2GBPytWUsIcW141ZH6p1TSqC/LeIqzn8gI=,tag:6kcPUpS3DsI5TWvTUR0uIQ==,type:str]
-                      volumeBindingMode: ENC[AES256_GCM,data:6p+vZo+yFp8q,iv:ALd8viaRZwe76CmquTeKOLvFtTtX04vM0NVGhKajy20=,tag:8O/mQwPD/KyJ30cJr/FsZg==,type:str]
-                      allowVolumeExpansion: ENC[AES256_GCM,data:7DBq2A==,iv:7GWR+TFZ/iX+SHfa+Hl/JRqjHMuoA01FpHOA7p+Jihk=,tag:GGKafXX2KyXFH/g3yTCWcg==,type:bool]
+                    - name: ENC[AES256_GCM,data:430vvzGNLvJ1FoTuPji45htY0Nv4U3lLBvY=,iv:vqKaWixJlg6MiU6naJgJzTYX9C0wUUAYmXsyxQ2pkk0=,tag:NbnYzgm++N6dENGMn/Ws7w==,type:str]
+                      defaultClass: ENC[AES256_GCM,data:7TBs1MM=,iv:Bpg47VI2Fj+bWzwfPjjfmS5Mi1VluXJl2mcqPi7LIFY=,tag:U1p3dWpGjG5CX/jPMcusTA==,type:bool]
+                      reclaimPolicy: ENC[AES256_GCM,data:/ox2/NU2,iv:RYYqSMt9UALG69V9lJYRWx3k0n0+yU+1pT9STqkLkMI=,tag:fg4OODrc7614+pBPFLz/0w==,type:str]
+                      volumeBindingMode: ENC[AES256_GCM,data:+Woagk2Ol1j7,iv:yiGOrAc6Y6MiVzKpOqTZjwldwb3G2sItBUmHgmJfJ9Y=,tag:C3ewFTR+0driCaiTBmJUqA==,type:str]
+                      allowVolumeExpansion: ENC[AES256_GCM,data:EVtEZw==,iv:xb1XdI3f5S6r7kHH4+wCUZFnjsQxaLtQtd4M9BmVE5c=,tag:PqitHblYXWULijonN9x8Qw==,type:bool]
                       parameters:
-                        #ENC[AES256_GCM,data:GcT2Zxr75aLcREcvPJP4LrMiKPURnmTLyWyHs1lLzHvMfI1XRi4MxvreTkdBk/k=,iv:fcYGBPPmK1jn4h0I49+AIlBLfoMXtCPZsqJjiIOvxS4=,tag:RD8vQMeoGEv+ZzEPbJxM1g==,type:comment]
-                        #ENC[AES256_GCM,data:Q4FM0Mjskckd8K7+EBdB2G3BvdTalg==,iv:XN7SO0NkU6xxHttOLh5oL1VO7M9brWnmE7BGxVEaI6A=,tag:cRArlAKyRZHeRHttnqwGxg==,type:comment]
-                        fsType: ENC[AES256_GCM,data:Ny5tnQ==,iv:XIern8dPpf1649Cy9AXBEeI0MeTiEzG+hrOYe4hAlcc=,tag:ubNFyj7BQRUfi+cBEYedAQ==,type:str]
-                        #ENC[AES256_GCM,data:5t5MpIpEe/cHAbmwRkud1wgayEs9yfWa6V4hJAOOQ9nCFL+o/DgNvHJIvJgWJ5J2wVYwcxfx,iv:NFjPDq4j4ZE7IUAu3sYiYvT5D4T0DtDPV2gguMyfJi8=,tag:QY5ta4PIbvqkVcT4f/QHoA==,type:comment]
-                        #ENC[AES256_GCM,data:qy1htEGuYat2J24RncYgWNKEoxr27sKtJaxPG7//0y/p3VNkud4abw==,iv:jRlQKJ4UC3w0VC9XuvJeLHTdqQJ+awOGpdmZzJ6Duis=,tag:9HQZClE2dYgFcpvEMC+CuQ==,type:comment]
-                        #ENC[AES256_GCM,data:KP/0XAAz/gcsFcha3W/BuTnrPQMWbeu8NvKzT4CIh5C5YQd5Nn8=,iv:6blo1cOmJ0tMkvcxS19v9vW7Y8hNR40G6KnAPRryUrQ=,tag:XWeZfogTkV1bf8/Z8aIKUA==,type:comment]
-                        #ENC[AES256_GCM,data:6mC8dHJCZPcuaoffvtnQ2QqkIOo4cnC+pXIBEObgQUQ3RyQpC1Gqx+9Sd54WnfJcui44tQ==,iv:sSmaADaO+q6bkKGGqsxM84w5ekqPXNC1glCgxS3cIm8=,tag:tBDk/VScYDk6VfEMRZIEsA==,type:comment]
-                        #ENC[AES256_GCM,data:qy1htEGuYat2J24RncYgWNKEoxr27sKtJaxPG7//0y/p3VNkud4abw==,iv:jRlQKJ4UC3w0VC9XuvJeLHTdqQJ+awOGpdmZzJ6Duis=,tag:9HQZClE2dYgFcpvEMC+CuQ==,type:comment]
-                        #ENC[AES256_GCM,data:Sovf4MpB+N2UFY04W3oZjq+SjIBortwBMdei6nDR885XdiC1,iv:F/ClofnRvAzLJ1xy3iLvAg0x3ssn7sL1IXahapHwaP8=,tag:f0txtEt05VmCNP+3gsMrJw==,type:comment]
+                        #ENC[AES256_GCM,data:u7f5cjn8ShKTOPTp250P1ZLGWgEcepVjaEoELIPEATZD7BaUn6MCkBCE1rVATrw=,iv:q67yt2vd4A7Aj/EnYuC6nuFaJchgEfilC7LgvCzsl9Q=,tag:bhYAn9koXdVTkk1BjaoqDw==,type:comment]
+                        #ENC[AES256_GCM,data:FJH2hRlEJovpXqI6qx7qRXl2jIMyIg==,iv:dT280/F1H5urV/c5xTOSv2CDpD0kDn6MZisVmaARCCc=,tag:kSbBw1h9G/ACUOX3GcJ9CQ==,type:comment]
+                        fsType: ENC[AES256_GCM,data:QwpvAA==,iv:OQ6e3iquTx5RRz9apzbzDudwy+aklq9y36VkbyWdLyU=,tag:lSmZnUYajFmM1KafV4Pbug==,type:str]
+                        #ENC[AES256_GCM,data:jMGz68ynBC0qk293c/SWCJxW2Hs5hPsJVSbswleDHhHMznjLlCspnoyYmhSdfCarQa7NKHmf,iv:18R7Ow2Sy79IjqPeQGmLZGfoiv3t4dICd6CPo1zXTtU=,tag:exZJpVDbi5sW63752upMQg==,type:comment]
+                        #ENC[AES256_GCM,data:t6zNpd6s3aFf8Vpra3BnRcl75HlZlwzHf3uyoUEpshhCU64VgT0+vw==,iv:u1RdlVY1e0JgHji36vnhDjlsQr8JTQpNFViqtQ/9c+c=,tag:G7vawu/J+WgCwGa0OzsIFw==,type:comment]
+                        #ENC[AES256_GCM,data:pNuhFuAdGgCcWtNmgqmGqLrY5swPuz/1M56hKKicd4O+wNP0rmk=,iv:mnoHwQPlLfR023dZB6zwBwQ+4drwIGS6Ck37Q7vDYKw=,tag:S+3wVqc5kTheRY42zgikDw==,type:comment]
+                        #ENC[AES256_GCM,data:BLprwka98//VtoeMrMlO3J0ctT0lFcx1uskhM9d486oIttDL3TOE1/JC3IuTqS/Y94O+zg==,iv:ktD0ndjbtp20Gik2Nv6tb5Cx08fiRolwzK9Lc5TLoSA=,tag:S/YqAcfGJVpweAVSPkuAkA==,type:comment]
+                        #ENC[AES256_GCM,data:FSjMmBHz9BP/vE9oPrqwH7Hm70+MqGu2DsrtRyuVWiLlMyOKtuPkdQ==,iv:nVd7PX1p5tGtK0iyFGqrZjORan26FSpnYXcAiYoMdOE=,tag:lZlIF12ST6JVhIqtWRkvCg==,type:comment]
+                        #ENC[AES256_GCM,data:k1MevCqEHIUQ09HRt0WqOkTM974oWfFeDQttf1MvXWaPhwhp,iv:kN5Yqsp4zs7J9UKlSJAwNSQ+Nc9bDW2hrFpWCZR25dY=,tag:BWKdXqfTsE/ssX/WBVcRwA==,type:comment]
                       mountOptions: []
                       secrets:
                         provisioner-secret: null
                         controller-publish-secret: null
                         node-stage-secret:
-                            #ENC[AES256_GCM,data:TY0Oii4ZzbHcKVhRiG1DEmHlyhnrVNLpiXxh9KrWVJevP9pvBzA1Vd9X6RciDwzPPVVHtq4NAWhMZmHlfutanL2ghdSd2jDyYbxF7SN7wxMaU4h5kXxyCXKcNKL1igygfIQT7T4=,iv:ekfrzYlCHhHwm9jNaPskCY4ebCzNf/1rzC0hAr/JfTs=,tag:lqkIp/73BVK+zZPIomFi1Q==,type:comment]
-                            #ENC[AES256_GCM,data:hMIn2O4kRtmHEh2iEV2qg4qz1hZ1,iv:VkfFSnUP79Jzib9cmq7lbMZExiO+UQIq7BBmCLESkuw=,tag:OEvax36YJ+rGx2FVAWzehg==,type:comment]
-                            node-db.node.session.auth.authmethod: ENC[AES256_GCM,data:Q2/Qog==,iv:5y5faCVVQwMQ25Lb3SdRyN6EDf9BVZ9rPWgU47VgUAg=,tag:NFyGG29EI1Bdqm6S7ZvJmw==,type:str]
-                            node-db.node.session.auth.username: ENC[AES256_GCM,data:cI/6CS4RooX4L59AEIw=,iv:7xfhheyaeLk2B5ZQwJo1oYsBbP5PXe3YGo1dIX9/I2E=,tag:FH2HZUeKfuvG/Yk7t9AUwg==,type:str]
-                            node-db.node.session.auth.password: ENC[AES256_GCM,data:XYi3e3PrLQRy2eFcxNE=,iv:D26Q7L9AlKoc3q6IoJIIR4zo1/gqO1i5PjPPkcDIhVo=,tag:YWboZLF+s+MVP1kBCSfqtg==,type:str]
+                            #ENC[AES256_GCM,data:0YNZuluQExMTaa9rjtTqaETVt1eBYBT90AYF+APPhcdaIvyEm5Y8KzE7bo4WyRYd9vGrwamsgpw0Ynma3ZytliWMGLWuDNKahnuRxRzyUMqx9fut5hVQrpfoy9X/6G6cSSvWbbA=,iv:DvinCg5TriANLlnh2L2WxC/SCcNBOlTUiLrbciSsMlk=,tag:Wr5J0gSN27PMvavN1X/loQ==,type:comment]
+                            #ENC[AES256_GCM,data:pLhPk1e6x4L6YQc2ap7xq8Kp+nbK,iv:yM0EgJ+N3LiqyAkG0AGeGpEJcVZOnfmCGEAw8PCA+TA=,tag:xqpk3i/o4a32c/byrqLrPA==,type:comment]
+                            node-db.node.session.auth.authmethod: ENC[AES256_GCM,data:6tUCTw==,iv:cysB2emkYjY9sOSopLH46VseegA2Lof4+KrnLXkoQFY=,tag:6V6OoArTXv7+XRZbXMk0RQ==,type:str]
+                            node-db.node.session.auth.username: ENC[AES256_GCM,data:AbYyfk1q7sxbyXue5yU=,iv:2Cv2feMmhptBFxeJoMO5iSh3M0DrfjUm6E5FVJM9js0=,tag:7IV9N4C6iVlUFeo21ieiZA==,type:str]
+                            node-db.node.session.auth.password: ENC[AES256_GCM,data:BJRGlbS3dROD1Zi4cAY=,iv:DdKBnTcHyehpduVQqGqD5S7XrN1JGo6QbYTDGA02lZU=,tag:LwL7xhgQzzQQBykJrG6yzg==,type:str]
+                            #ENC[AES256_GCM,data:ozqTXjtsnzrBttzvxz8H7gRWD9VOYoM3IYCJfMShVwz4jnCQBZl9DSz/EK8WTCA=,iv:Oe6ddLK9n9fXTVeD8kScOc/BtfPjibWlfoZAENLFFB8=,tag:ZvyVyq9LNRmXvaHBJM69xQ==,type:comment]
+                            node-db.node.session.timeo.replacement_timeout: ENC[AES256_GCM,data:3lFS,iv:Lnls8YO4tDMVaCVJGHlZ5CVKfrr7VMSbBn+B/5RLPZg=,tag:XSnra3eWbj5bTvairldEqA==,type:str]
                         #
-                        #ENC[AES256_GCM,data:x27jpC20sEqj6JtW5eTuD2s5kEqPfyp70pExcg==,iv:+AV1gDpAAu9Q8kqCcu72lTntEbQe8Ue7DEgO9NZl6mw=,tag:KSyyK0yfPCdbhuqOh93ghQ==,type:comment]
-                        #ENC[AES256_GCM,data:sEyoks+gRlaJ6dS1K+oGr+EjOY7uDZcXWVXzVJ/ljiBZizGlGD78Qw37LOw7/N9W,iv:TNOA+TStaBNOctUWhhpdYhi/qYSgi9YzDNAj4uD/LUs=,tag:bqJ02/+eo6qCvcUGVGuTkg==,type:comment]
-                        #ENC[AES256_GCM,data:MMtixtau+9kMxH7ttV5uxBGYYBZVNYFsn0mBRlBf1/iGzTpLnrlZwSy5aQRvGBfQ,iv:+nIr0F1rp/YsTtlLVG5m+CWNgDLLnzfyp9h4CldvxZQ=,tag:a0rrSv32T2hgJaIk/I2bYw==,type:comment]
+                        #ENC[AES256_GCM,data:FZoxQJcwvuRaQQM07+bNzyJBRkxt9xvf3XIjuw==,iv:s+zz2b21ecwcyxlrGciak6wXCFSRzu/HQFPhj+y7ubI=,tag:yQMqzctsKyUWHOpvd3jVoA==,type:comment]
+                        #ENC[AES256_GCM,data:ZX3ZlZFLGbz6kY3R9vDWRBfPuhRBHZKovTX5ZGSU3iXKIgxvtMtyydO85PMqK0gO,iv:pNe91i73bzCiRuvhaVuXmhDpT3Xex34IBont5tPRu+g=,tag:DUbxuHD6LB1CKUgmPDaVAA==,type:comment]
+                        #ENC[AES256_GCM,data:p2vQmF0/uQRpne2tp6cU+94u8eLyIvrC1vdnFSwc5LqEXtUIkNXQRj1ww9bk+UDj,iv:4kWLSfOYgbkN1VojnVkUWM9XwKFjwwSFeBbcr45F4y0=,tag:j2wFf2X4lVDq1lwE8B1z2g==,type:comment]
                         node-publish-secret: null
                         controller-expand-secret: null
-                #ENC[AES256_GCM,data:OgeNZBhHQZZy+yFVl0M8RrKkby5OcztKgWo7yoO50qY7AZSvUHRJQPU4e2R+XqoSdbIqMFKvpRQ=,iv:HolWvt1xvXYMjZxRkl4R0YO5KEbi2CHn/WrXrN41Zo8=,tag:KgjWtD+76BSP+lThHF4cOw==,type:comment]
+                #ENC[AES256_GCM,data:tdcZSkDPGV1+H+8U6zDxsPK9VIDS7i3f5ML3IhdRpRgAUlAIE6t1NfDQMiKVvw9zXbyZasY9WR8=,iv:DM9sq7VU4py7ud7fgUtr8tS6XtontrtqomJ1Qbrn4p4=,tag:9LZxEJd8eZGL8BUO1FqJ+A==,type:comment]
                 volumeSnapshotClasses:
-                    - name: ENC[AES256_GCM,data:fSwZVXvVoV+JBRwMgxqOR9oDdEJW,iv:IpGLW+152FTE7RjA/mfeYP/VXkislH3xUe0tX+BMxGk=,tag:6HJMQT/VSJaaN2rDsVdJ6Q==,type:str]
+                    - name: ENC[AES256_GCM,data:DSxa1DmVKg2uto1plq1Mmnb94EQn,iv:xYoHj5s8nBf/MUQBtdx5pwctmkeXe5PBmPUy1WB8XoU=,tag:RUuGGLA1eBR/kQNClFxwxQ==,type:str]
                       parameters:
-                        #ENC[AES256_GCM,data:WQ+CwYHkyszXjMg6Rb13QHIxY7csQjwKTLEV3hVK1NC4ZWzJqyX0rUnex0DKj5BCZyifDOo6DKGW,iv:3wcOxxV8nqSESB2RLfNdiRWg0HYHE6yyoGXkklLOyeo=,tag:++zU8Mlpo8Mh/P/EaIPcmA==,type:comment]
-                        detachedSnapshots: ENC[AES256_GCM,data:WJgMsQ==,iv:jRyuMQXnRQckqZemRlquWbEifouZ0mbrHjA7doMaTNg=,tag:MvA+FwMB8Px1kz1+B8iuqQ==,type:str]
+                        #ENC[AES256_GCM,data:Uoaq4ZqBHJ3zyJBEVLozIuKSbT2d5Tks4qVFE4oochtL+Kk+uUSUWFH0NfVsiLVlFOn95sRLZ3i1,iv:nNhjLrGKUERBQO7WRSO3CoayO80qDonUu9J7k8/WwmE=,tag:I+8bLoqeP9qSH8IfO1MP/Q==,type:comment]
+                        detachedSnapshots: ENC[AES256_GCM,data:pXSg/g==,iv:giGOlbwOIpAtNIsW/Z4RmU/APvad+x8610C3kwx4370=,tag:sp4M3FaV85swE/LKBHRNWQ==,type:str]
                       secrets:
                         snapshotter-secret: null
                 driver:
                     config:
-                        #ENC[AES256_GCM,data:fqHl4YFP1GhClrw9fJ8pnogeWLJRKP6cEZ0LipmK6rann9Zpv43Lq44cHrpjVPknL/kD6nnn/3zBE4rSEEX/05cJ4p4wW3B5eA==,iv:J/fTDMLe0jyZi+w9fPArMvXU25joVUmXo4vKB8Crr7Q=,tag:t/yJjx6h6Vb5bm6Ul0RJ1Q==,type:comment]
-                        #ENC[AES256_GCM,data:HA75KZw7WvQfivg+jI/pd5N2aN3gK5WNaC1peGqxDrh/1JG2cAsuirSKqHc/ERw1NQIKRde7Ja5AlR+/oVaRxXfJhToNdg==,iv:pfVtNY89wdxgv7lEoftww3GX7yJZ0vVKs2/QNAa2mto=,tag:JT+i5P5KeREQRDjXqK95DA==,type:comment]
-                        #ENC[AES256_GCM,data:be11ijbYjWFdC1R9Y1YXXQgud0MaViLYYI0H2nqsd/vBXrNT,iv:uBCKGdMRzb1GdTao8P+dwBv2TLGb4Vum9Zxrp7VOiew=,tag:fjVITcxMmip1fSxHzxV7vA==,type:comment]
-                        driver: ENC[AES256_GCM,data:6lQopEVA3HkOzljH6IUOon8=,iv:OCto1mIm3DpFVKps5sR8DRI+jNtsbOsQ39mcdH56F/Y=,tag:SCUQtancEj+bCKErYGVINw==,type:str]
+                        #ENC[AES256_GCM,data:NY/+X5WmYMadVg0cA5JfaSfU5KZrTLHGd87MlGPqJyxP7sBbXESmGmxdKlDkKebxozQ/gF+5JNHUK/H7xL8Kc44UEu7KuzEG0w==,iv:WVnQ9LFyNlG3q9OAJcXbom4rMVDtkeofi0dRy5/P9QA=,tag:WtzI2Vs/M9s3fuwgnDfFvQ==,type:comment]
+                        #ENC[AES256_GCM,data:udSoHZTQYcPKxIj3AcYpJDUE6g/iAidHE81tWqs7Z/uNXCjNnh5NL0TCIBjB47dKOAaIvZOT9FYHK1v9w/o5iV0R8PNNDQ==,iv:8nwOtdZGVUqg+ZstmXVXhvvsoQi87f4Mswed2h/D/8M=,tag:rQk8eBWCUWdfBtU2Rvc5dw==,type:comment]
+                        #ENC[AES256_GCM,data:mz+GFizjd8EweTOPASpNcK7uWg+b+uB9ARuos4evJiH4Be/v,iv:Q/4Yx9uQ9Z+RIPEo2BmrzgmWmJCqCplSk+itbxleu6o=,tag:ZJMrG4e1uiuj6G/S2Gixfw==,type:comment]
+                        driver: ENC[AES256_GCM,data:IgVYkezfFbV/5EHc9TgPLic=,iv:I0vD+iku85DXrFQry3JFfySCmfT8nFXH3o960usV888=,tag:Zf1G4B3RdWJR7oHT8qj6Aw==,type:str]
                         sshConnection:
-                            host: ENC[AES256_GCM,data:eGWRc6e7b7Y4,iv:OFH3f3KY4L4yZWZqqoe4Ux8RDPRS0N+LHPpbDu9hCKg=,tag:poUpgrFBp89EWkQfznKneg==,type:str]
-                            port: ENC[AES256_GCM,data:7L0=,iv:HrSdntwBRIF7uGZxVcIIjxoKC7VGdWaLZHMjR7JVJyo=,tag:iuZVNMCk5FeHXA3lyfZoAQ==,type:int]
-                            username: ENC[AES256_GCM,data:zHQxvRu42u8alg==,iv:m6yqlGHiTC79V8Uyc8dF94Rf61zHxJibRoK7mDy0RNw=,tag:vLjfO2DUzfc/Vn1Lbt1YrQ==,type:str]
-                            privateKey: ENC[AES256_GCM,data:STguk4v3QkcpgPttUB74kkeEQuqArnuWRkGAgtUH+N4mumlGu119iZZqzoKRVHlHJRVz/inVF/HzUESyHVpydKlNfVBOO0yP1LsqarujW0jmfRX6TFD825daqNt+FOf0FTOlB+d6cus4rRuQ6xEkRLfSB7S+Hya0oldaLjPQcY3XOlf4tdUSNj909SPHK0I4RfyPoodXUPkW+hLcWJzroPoY3WyYB2aI24v7DvA5bhG1y+vVGURI/XCF1wU5pAIxj1GuaSbrGIXPjf9+tVHHvMoStD1UegvQasF3erEJEkjZlpwj/038pC4RME7hhD5VyLa624Hy/t7a1O2pzZ+c1dU0VkSMb3uR4se7JrHxE/BooPYHqOgRyDjiCRi7Ek1/PQhvwHpDnSJR1hODcMW1XMPuPlH0+bKz41nusqIAt81OYN4L7RAJAVO6j+GmCHNKHAnUaB6YkRZkpYicSFbgQwJme9ge6V0z2jKDde1f2OvajLDji0r+cppB4eHlnJqEtfU6DQFpgs9A57KZQy2K8CjfmzjJWuLhDUUxP5LoQbnQHTulPOyuUIdqml7JJjcjki3Pj6o0Tn7m0Eo51szI+6i0DoCSQvYdmvFwn0uYUZAJuZwTi5Ule/bcbSrvFvuVqXO+PiUJMQ4Fqd3ettAyZKwiRhtu8sf3pWc2eWK3Nw4oDZZdRSJ233I6saQNBvvVLhXnOsgYvbCdpUGlkprrjaH36to2J0UYKlFr/hpmrTDJhJRZEDR6W8Wix6YCpheQlLt5x0IaCLB7kvGJrLoYFognzh5kGutAgExUd6pHIMJ78P/Urfr6l/UJimBknJOPR/uvKNliuYgF86XV1Rm4XupA5cW1nc/O5QxDk0h1DwUcvC2EUdFbkMP3pXwS7J2p5CKQ19ZmXinx8t3aIMGOgdY5dYnfd+gDcHLJDg80hsJoGubM9vijKSDN94UH/b/laywGwf8nZ/ZLHEJt+cnE2ALi9fRzIt+l8oszKxD+9FwdYZg1Ce+fKx3Ut9egBAhCyGOvmJMQd64hBxYm0xOSVpS5ehA5LfHq4kMRBXnrkcl5KPDf7kafnNn6wBYW7wpQPphXWvxKUH1OmqNJ4pahQrFiGisoAjI/iHx3VPYyUkqtmvRFNPsbFgwr+ND/3fgmYLcb91rchH+pwcEu38YVrCLN+pXYdNKvL6js+4ECIZ38YbG/6pLwsbx344CJhhqg2+aLK2Vx1C66vfNo5nxA8XX7k2/lDXEXoeXGNP6gKoqjQf1UMxCiYIpuQjRQkC6bFVok+v0fs1NaGijxbzfY3Fv+ZVPQFAkfm7zKKI7nY5+P3E2pvixkarerU7Myzsf4qdr33XOD3YtVBOvSIpCqxsijFw5ibDS0EStBCqmFGSbbldzqE1wNLLoRFq5xwmIAiuPKqF5Q6/GdcSY8WEPCyC7cr/2d/xr/Q9CDjFcFLUHnoNwJL1YrpSOkdkK9y7mgEnDOEKzkKHXSzObYYOcQx8Z/X1KpYB7GDdbkwTbsYI5D20Eggt0h5+uAKpoYjnKypdbMXgt1ZtzKDULmIdLMuMT5+PBcDXhKWiIEsW3n6kFMu6h6pS++MsbLmxnhz5aGBz+kROkxKoifDjzBRUZKwltuGTeasTfV/vqEm0z13DGz92gGff+yzO84FaZ4wUfnAKOWsxM0LpjEsWO6bYTmZtLjy8k541UClBoRjxRzR66z9ULKtTuY9gdNn7yBvOx++UFx7yM0coCfMjw3flAFoWBmjbUwrkQzbLXz+wuQbJNNn5Zf9NU9u8TjmvfJ04kM8DmP7Vnlxu4mwetRYudeN23S+UsJMGGSiqbLUxEn1MD0ILBvGkMYx/dIVVE7YnQRK3ki6PjvJ2Oe6GGyDrCrs/BE/ViQ4ZFLDThC4h6LT0269D3+dhSFUUwdeDKACPH5JwqyQLfDRSndC2B801qdvpk2KzM0nmttvu3/Rv0zVcUd148leh6/R3W8kzpGf3xBlnOiiLKOw4EQKGlIMtEQo/Rwgd/myo5grJEmGvYlZP4x1C3gF7zAj8OaH4RpoAeEKbu/c1cy5z7J+1lejSqvA/Vpomrjf8GJBkokFC/EyZiYW57S6BqR3NF9+ydjSrjQgqQoYZrHdWpch9EvhrZQXMiGCHUOBoLjz7+021XtxV3K82hf263cSdcunAnJEkWCKP70sQIbd/IDjN7YvjD7USZwLeXFazJvgxzF55bxvBoJwIAIkqrHLvYAwMZ5l8yXJg+VkmX8KeBAt3XMlfPch5eEImsBbTBSnQOCAhdOvWcetL9V/EP5P9nYr/9m4kUgJeRWS3iDa2KQhUaTOBkloxnj17dzdmu4IqFgKOM9YvBDcH+GUR772dkvb7qc9yfnxFWSBAiwuOeJPoLaDv9YG7M2Om4WMqM042+eTLRUBbXDb16wFOnSjsNAPDUcN/eAvqiICesy4xP6jxkatCQG5M4fgmwHC9NkGaCMLUyPhS3niJGlw/Cj53bKL5vbgGKsu5gbMz7LhR5/yleKord9ISOqumWHv0mEYQNzTZ3p2qLZYWGNaFZb6LIOybYpgvopUKLOHHWQzwXALIAt1m9XIrPvQMlwemtDkwC/eI5lNdUxYgrrFRElWQ68nxd2NI4WHoUEJC7R56d1ut8VoueByoqbWSHvs//FffXRwBNvxSeAhVXHwduJey2z2FDbI7PBcBeL1rzHaPkjApqaGFVsi9Rip1Pfmf12Lnck7AKJxhLUdPwzD0XyqV+NnttrEbKe0tZg3y0bRttJNsd4t/xV3T8EF9v9pZX4FbtJ5k/tL+7dG0hw+kM32/3a7/SJOx4qdDgUaOZ6K+60lNMtvsq3EiyF0Y8mvAlVBDQhfqYB8cAWMBEXEhgcVfOM/T3T5KVS11lv1ZCKkIALQP8yaxLRDAmjIC/mqj3EPtX0EZZ6jf//jDji9tR+ay8tkAo+No33MrNCToWkmpHwo+tQaMBq/qXQpNPS+/galkcWvsJebI9e+XMDuKoIZMo1j9iELnnG1cN/h4CqtRD0F2P3gXU8ckds/EU31WV+QSEd3GU/QZ/iG2kIB3Bs6TIHjszBBq0+HAi6g/osRKJECE69hho0cCPtGHhabZ9TzoFKmethh9vmRIYY5Fn1f9Jcivm+91UbESV1kzbksV0aUcA1H7zZhSDkujYnwf8WjE32YEahxvXg4sJTMdsVFxQzXg49zMPtjXiQkpT/Ab2OoxsMFkd+G+O9YSePTzJSiJC/EC1U0NbFwZI3+lP62V0j8zr3IF4MeRj+MSDXukg7NUq7D+NuGKsT7gma4XkuB3J2j/WhQWE8Uf64T0+DRb47x4M2NSHagC1e1piot01UjsawAlB2/nKsLL5r4/+YNv/r6WDjdpb9NOWLhcXNphhenWXpuImS2CcHgoUiGJHU0wpu95o7IZ+H9eOy2encYBKuyLAaTIL1hGITSiyeqxDhtOTw2wQpBbzjljHOq8eFC+H1Hjs/6Em2ATFBtrC0+JhrckCMz6opkYw1sTEvHEXrYQ==,iv:CoWJshswpK9Po9+UIdhGrkznxO9gC09HfeRA6L8Zmq4=,tag:BBcWHVZwTW9P+tgyNAjWjA==,type:str]
+                            host: ENC[AES256_GCM,data:LA7T89c12BG3,iv:4V1vtnfLspAXHRa8IGeqT4A09Wrr1LCJTOPHVExq2us=,tag:jnEZTgI7f711QkpUPUBlUA==,type:str]
+                            port: ENC[AES256_GCM,data:JAw=,iv:hUJY75GmuB+SapCX/uwG+d/YmxhEzTuZzvGz4Yaura0=,tag:Jw587HfwPC0Rf7Y/bGqH4A==,type:int]
+                            username: ENC[AES256_GCM,data:L1f0/vjHWstKBw==,iv:W+pvE/9yyfXXBJNiSTa35BG7VtioPo7Sg003VcL1g6Y=,tag:9uEqR34ucl6GzCJpm8C/+Q==,type:str]
+                            privateKey: ENC[AES256_GCM,data:ZrDFvqXyzJUSAPghTQErcpovSXwcQYLYXihxG6BRRJRnpap1Zp64vz8PIrzwDXVN5StRwakN9cy6jtIyI3zyNkjd3Uzrbryq6c/Q+8+2dEIe7PH0VvYJNR+8gEf5tSks2iozWDOFb5N0e/4qNyz+m4K4LbI2+66TD3Bhv5a+5cDM4W8T6eSjtUNyz5fueAWr3LZ19f29LE+75jS4xE7v7OwhVG4lx4WrERmnKvBUV+2tqtpjSTZRemTeStdLHkOCZgURDVwhdypAON0dkckHUUCgHBRet7U2/ttZeQKQLuAQEmil1MP4Y5iXoxTh+WJjG86pF+F7xf+2nPpLw9+IyjpbcFqK1CdwfiuRmp9zbvaZC5w7/sZFMyV4eSwKlQZE9UR7jf79wzCwEqgXXM0HKf8tDdMIFzm4dJ7eTBqDwQnbBE7SlraDp1MEA+uRxJUCjdV3QZARM844+CBU0aPc4qkXKbN52g154EV2ypGWJGzWD6R8F3QrpFswbCE7iCtiwl0SM5nay3zBOwQIOtLPkV4jTIHjw6WIT7vS+9R3sUOOk2FdY6hif7G/nl6lPDcbuJe42/AV/ARk+5D3NaZRHTcGOi+YvISl68SnmaZTQNSrOTIVcC/pkhVpuvNf4sPvV5cbP5kdEARzAnWaw/E7bL7TnTmlq/aTdY7cAR8LDt/Ewf5RJ0rTfk6AEFS4Z/Q7W+jN71O+Ksxct17F1JP9sG93CthQuyS7x+xSgj2JVfZW7NbZwa2MZvG7W6onLuNe4zQXaP2rgLgfphcRSuPYkqkLXuN9zzUShH/6LdH6ZLSWrTPteDXVD8BlFcuyEqEwCPQKDSKaT8sOPyyQyMCRuVx4gQol/4mS+4HNY/E3fmXEcABrhoTKCIH7paI4qWQlcbmZwvDMZjsm2LjDLWh8TzlinNLZt0rb0ydbkx7UZgSyv60uwWYIyCwSgiJbuhED0P51K224O6gYuNtXkZTYuqTyADmOBvNxYVEvy2dfP5l7HLAFL9ynsv5hlzLOghyW4ByQu2jxLLelPNs7Q0CJqdtbTk8vbrLslLu2mfJhjJl4hFSMTjEdGDbJ7ux4exbFMgkfRa4ssiFZhNEFU+DzqZAFOX4Qblr9cAyTY6h9WtPgcdDR/PSLkd3LykpYmBYn+hDxt8gtz1+Fxx3gfNh7ohTvC8bGPp+w1Dr0PlsmiaO8ry/27kTxQ/nVQeI/w9g7/19bvwDykYS7fY51BhTY2IMyR4N5D0TVCvr7aLXAKYgtAIBn5Rb3oGg/tKwgstJHpqfUyh3dezhp+hw4xm1ub9VIukgFsNz2dUClm9OhcI8bb5hda2yzEc8R3IPLQ9IAYoZ9dOE2Q5v8KEHNFjYZyGS4C2cSEFoAAF9vzonmrfyMPrQZ7fkqW5bFdQ/xPuSkwC7ACXItWZ3romQt133HLMzgBzNqmOVW+gXDgV14j98uu3dllkJ2sHHZ4CX46+qrEuDyxKojI+9HSQpBB08clumq4TnvKaO2WpSjV1rB4zrs+l+f97CO/myIU4azYJJBwFbEqfkBPEWftTSyXK3RSYeq1yJk+G+dwh33DOlttbFz9wiiQ4QpdPEpfljikp9R3l9bMaLD1yAN/MK0G8FLdJUC1ETESHAQu9ARgDA5wwjimT9RpAopcTaMipQm3ZZacLQf9UHzELosZ8Nh3nPGfWo8rD1LME8N2Kgp2LyXcWoi4CZEJkYHZurpy5NilL7R3li55Re0KqpTM3W1/d9yWjtTLsK+1VJrGZ1IwlZ/IWINeTic0kcHhgwkpGzC8bCLUEYRuanEqFZawRvOwAtg+aNDNYNtzXhmfblCLBDJFT6WXExwFjUp1h/6mGH0S1X1owlH0lulQiVRfRQrYS5tjPbogGdz8qgK1QwIjSFFHVPG4IC8Xj9pQx9/8fNyjS4ZAM118Mu7PhNu8zddvcWGiJZgPOYRqQeHg9OJKlsV9TsLIBZ8gacszKzYkt00p9GvGA613C0mQ804WhXJUlBAWy/v/sXJyS4GlYb8sP9+jYBVJU3+cR1pPA/wuZm+S9KDF7mUUbgDmcUAKekMF61QRTmuQ+5Xro/jPvcJJAg6HmeRMognuui5Onfcq8J8Mn4ghN4pJyESQQmXCVG3WMi/OIb2j3D8+OlgOgbj6RAhByDl8DWPbOtUnc9hFUGkLcJgisWa1+fdIuske8HeTGKBOcoJl0jMiIV7xpQLGFSdsvKVn+zOveaXmaYWEEOnXySDhGgFvf6WZ8jrxEDqKnFilwZrZjdLXngUsEmYYMgoPfi+rUcmUCqyLOqDqQSfDsxABbfa6/3p2OFhiW7ADN4gmbGU1NUiPC6mh3TRBb6p4OFtyo3RQoDTaEybuN83QCtSoFzq6515aGyvfM++CilhpabfuJ5xBYRBsFWqh26WXdiLhXBB631i6xWwzGHP5ctCRZ8Qcha/FHHIjNnmu9R8AIg0r1Q/4b92up46VG67sLUsV1yQ6THgFXtLyVkvcn4bX8oQtdMsQ+Gdsj0L0PFOY1W2nQCfvRVRDdV+Hot/lFOYB6pdQj+KZa9019VUA0yDgfVvMTmYgXGZZkRK4IFRMfRjDRHXEhA9WQg8Pu+zNwjyfZR9LuHN88iEJ4ICTiy9PV7tqmUE8lZ7F66Im9Cmf+7Aya1nM+jI74LBD23493rbXT0eJ3nv6EYzd3vVIrYlcokqLetoSAdFlthIvbDE/esGPjzCwLS+oyhmbA5+1ZRe11kz2kCR8DFLC7nUfGLgNeWPxpan/rD/U8Dz1a763HTFCUnxKvvZAYsj0LPMQgVaxF7bWL4YcRF9EIebP4sWzuGPqOKf81cWdGHkxbrCUaNS9LbxOPVO5DjAJUAJadalOHJQU5gvucnXUNtmFb0oYfNWt+xM4M5Cri+ZX+wAL2NEm6em7maoCqkfcQu76gTTBiNkelSXXK+arVJ5MvvIxpjqsV3lwLQeGxgZa2JpKnf8nRtxYiaSrmNF2/W846T0jZ9vK6ENZJJ/nXAVpY7DORFxac2+e+GV7RHeaxiD84Hz61pfjDtZVgs8Nn5+lY4Zz/dFMRbJAA3xjyiIF4+E06YxaBj5SP5fqBTCmRzOC7OAcTGjrr5f5Fv0/H7ixY21Xqu0bbTJxKRTWvBGd9UNCkp54K5mqTM07QqFirk+TsaxkU1R8hjfx18wmy8h1oSxm/aJQVbEQBBa/5xA3+fmaRzMD1E3Ib6pmnBEZzVBJbRCZOM6reyfUsDRFzxRY4P+vUiMKkf9/HN3SFfO7JqZEZEnoFMy3K3lfh0Fx7Sgkz93y0s2kOyUYztY1rnCsfGnSunYelGA0jV6S0SU/sWDERL13TSRD73L7TU2sb5U+j7EW5sYRpPl46vLM/QXWeDryxwylkpHXuEx7mdWrJlrfjHtq04bZrrpOmNPfV4DEVqmqQMWkBDfaeEWEdmg8Lkx/C83NWMCW+fYfrUm/3taY5Z5UARBpiCZyc6xgQ7MQJT9sNiEZuX8dpH8e+2gKDHdg72dbjLkQDvvGA==,iv:plY3Io9bJZvPcR6UFjruJ12gInxEvK0UqI+YWuLS9jk=,tag:1ogNs3lFMOv6tZL0B2FsCA==,type:str]
                         zfs:
                             cli:
-                                sudoEnabled: ENC[AES256_GCM,data:JXsjrg==,iv:xOnCcoOSjbpjPT+0Zc56rxSnFtLaRBFdayyuE+2g9RM=,tag:v0BYhs/AmtwFUCwlUBUBnA==,type:bool]
-                            datasetParentName: ENC[AES256_GCM,data:dNSgWoyFGW/5r/9Y55yvQ2Y=,iv:wZ2mMO+FAJBr7tvFL5+r1bxw2i5oD1rrJX6sdjFVdqY=,tag:P/KaiDsLZ0NUjXjVM4l/nQ==,type:str]
-                            detachedSnapshotsDatasetParentName: ENC[AES256_GCM,data:6NEArHLvMNi0Ac/sNlIriQofME8ViWhypynL,iv:V20ZnOhitCjM2hZqOznkf4kCjRvoDNW/0qqYlBwdNO8=,tag:1dPPNnu2WKk4OQB+6+TUmg==,type:str]
+                                sudoEnabled: ENC[AES256_GCM,data:MzXIeA==,iv:wzoQ5lzyja/XSZEX6ofc3nfA3bAXqRxcYfeBVVGG9AM=,tag:6YO9iXMQtBjr2BoWWNbLIg==,type:bool]
+                            datasetParentName: ENC[AES256_GCM,data:zn6iAhJi+NoKxjCnyPCkuD4=,iv:aJF48AG+bbX5kU8KA4hA6epSzERgxZY9OLHjDlIDOKQ=,tag:e6+janKHblBrK5vX0a1Hhw==,type:str]
+                            detachedSnapshotsDatasetParentName: ENC[AES256_GCM,data:DdXmzmuCqajt85zxxvzvCQFuQ9W8ogGrW8dk,iv:/P5bskm5w4TM0AWLtp9SVzm+4vUcZ5Bvju+BjDNlfv8=,tag:bynV0Dn/6KWyyYLAN63aJg==,type:str]
                             zvolCompression: null
                             zvolDedup: null
-                            zvolEnableReservation: ENC[AES256_GCM,data:dvNT4aY=,iv:26TT9h7ReEIXXQXLldAdV6zvkRvvRJ59acBgXvS+g0o=,tag:QB9WJWLD1G1wTdSEVMwVYA==,type:bool]
+                            zvolEnableReservation: ENC[AES256_GCM,data:2kpEhss=,iv:4675slgxEDqR/IplRmo6Wk8Mb7fuVsh49aQPAwP1urE=,tag:/ik+sTiyuZgwmgH2XAepWw==,type:bool]
                             zvolBlocksize: null
                         iscsi:
-                            targetPortal: ENC[AES256_GCM,data:l14FnjZLYiVH,iv:iRtAPETG1qQnbB7MRrCsGYFVtDvApacMg2D22P8MjdQ=,tag:HGbixZokCbIC8ITevU2CxA==,type:str]
+                            targetPortal: ENC[AES256_GCM,data:A5/SiTq+GVTV,iv:2/GTkvyySE3WUuLk8P5n3Gko37+TQ4jKLrRkX5opE6o=,tag:xHRBF+JC+BUfC0h9Qnr1Vg==,type:str]
                             interface: ""
                             namePrefix: ""
                             nameSuffix: ""
-                            shareStrategy: ENC[AES256_GCM,data:ERkR,iv:B8Rm6T5E28kVXdj9NDZA0CNIdid7LjllhChHbiiflIc=,tag:bAGgs8V0Iyc1rHteos45KQ==,type:str]
+                            shareStrategy: ENC[AES256_GCM,data:set6,iv:UWEAw8eENt+mkAHxqw3EDTsPstYhTdMzKJu7GKqNyK4=,tag:11ACulVd5lNvw9wyn09iRg==,type:str]
                             shareStrategyPcs:
-                                sudoEnabled: ENC[AES256_GCM,data:vNaM+g==,iv:R8SeaMzB0tarty+o3JeN1p3TLrgjG9UG3NQMtko4r6k=,tag:2omOQBqAaXFdbNk9pMmZMQ==,type:bool]
-                                pcs_group: ENC[AES256_GCM,data:EDmBE1pkWkhR,iv:IBInJ/mlsUXMLYthhdHgTcL5tvgMD26Ccg1B79J6eYs=,tag:BDqUmmPllqb/2T7BiPMLOg==,type:str]
-                                basename: ENC[AES256_GCM,data:OcgL87YJrhgpHJ4GwXvh0pRPOfsOGmMkc0i2CgeSPQ==,iv:n6SH9tYDlG77Tp0V+d77AjGFa+SdoFLR0v5m0qa1PWo=,tag:noGNMtBW7MlQmayTu2F1Vg==,type:str]
+                                sudoEnabled: ENC[AES256_GCM,data:9iFicw==,iv:CwRrfEDTzjZFZWZrleFm3Erd7ntQk+MNYQ+eiNOL0jk=,tag:YCT5bg1gG2yr+qT/+t+jfA==,type:bool]
+                                pcs_group: ENC[AES256_GCM,data:T3dPXuMvWmn4,iv:mhkYyzB/TiiHfbr/nA8QesvlNOLRdQxKhziTmU4xwrk=,tag:+LDZCOXE3Gmo4ma4bVJQBQ==,type:str]
+                                basename: ENC[AES256_GCM,data:Zl5wS3rBAK9VNrOdNxDN3E0DfkSniFafWDqUAh8o2Q==,iv:LVsC5DPSx7DeqCwMreJXD7LS+iC1GAtR8EpUhebTkfQ=,tag:IyItAeiwv8jDnyYoPZQDrw==,type:str]
                                 auth:
-                                    enabled: ENC[AES256_GCM,data:WQ==,iv:c2Lus5k670K388HR+vrbl3R1tl5nTgMYOyrbCELyh1I=,tag:2v8DIOdeHsupssTrWVWy3g==,type:int]
-                                    incoming_username: ENC[AES256_GCM,data:Ulgybu5lbo+24LGI6jo=,iv:QwuOkQ20DJE5R4TmUbwWzC3xLrW9z78bp8n+AnYaq5U=,tag:QRuJT7xCpSoQmxFJRDRiCA==,type:str]
-                                    incoming_password: ENC[AES256_GCM,data:8/NgjEoDE3VkqtV8OSU=,iv:moonBw+eEZropFoPt2aXRp1+UvrzAnzq7NZwG+XpF7k=,tag:vCQlgpO/KC2zE5TzWeunZQ==,type:str]
+                                    enabled: ENC[AES256_GCM,data:yw==,iv:JZqkHmxO6E+V5D25bkfpQCiH8OEy7tBDu8rk0CQDN00=,tag:3QJ9Elon89ZCm6l5XA5eUA==,type:int]
+                                    incoming_username: ENC[AES256_GCM,data:0Hhck4BIQpYTsJtITRM=,iv:as13h1jiH8yKWsvbgLk2oEdHlzaDaTvlKFvTv9dMrfM=,tag:Ah+geZnPpiVaWc47aI5yOA==,type:str]
+                                    incoming_password: ENC[AES256_GCM,data:rhqquZu2OwCIzP5ngzs=,iv:rR7DJ1e2lgRPGQkIFs8o6eRGy6YxT/nTf0dq5I/mRhM=,tag:oOk0kvDnC/jVcb+pNFs5KQ==,type:str]
 sops:
     age:
         - recipient: age1v6dnmkex8qstz8wrp3as58ap8yecvp5gttt67hktepc7s9kluvvsz94664
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHMjNKVnZYY1RQa0pCSURy
-            S3ZGTUw0TGNzQlVnWEN0MExzSHY1dytoQVJVCndkZWRUME9pNzQ1MlRQblAveGZU
-            MlNZMEtwS0RDbzdUeGo1NXhGcGU0Y3MKLS0tIFpFVVJnM09DZ0wzUVJaNW9IdTRs
-            RVFSUE5sZU9UdXRGdWFXbXBmZ01kUVUK6/2PYrfHKYRqRzPl4HgIqXTwoXf9Id+K
-            nSvCwMdd/GnQvvK2jzfil86NvGRHLXeGTeFkiIm0wgbd6KTHU45vyg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPZ3UxS3E5QnFPdjEwTHJo
+            TGFmeHZmMi9JYkF2Qk5EcGlEdk5nSTRYNEdNClB1ZlA0aDJtZ3I4NzFWY2lFVDls
+            TFFjcjNVei9xOEJXWFl6cTVTREM3TWsKLS0tIFhIRG1tTDdvMS9CWXhVOGhmTWFN
+            S0lWSlkreXcyQ2pZVVZsZHZYVXAyMjAK6/b+t9wtQduPuFNBrm9eKBjDBG47co2m
+            M/Yc5hrb9DC84vn7lreUBk4cwpwIxd3rnQYyiWf8YnjNV98EnuWKWQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-07T14:49:05Z"
-    mac: ENC[AES256_GCM,data:GHb9PJ5x0fEW9PzugX3OPiIQLK723pbEcw6AybHO3zYfWT4Mm4XAm/HJEp0JkaIA+v5uwnpD+MCd14rX4tRuDGmhM2C3g2E099nbLJwaeoOE/ptXhqrwzzUlDjq8GpgG9NGa4qub6JVcHMgHv7BGeMEgg96qXvaRxq1AXlPHh+w=,iv:9ppC8dmh0ZvWRQ9GfbMpxUo+qXKaE+1hz13kf8bIJDw=,tag:qfKesT6PucgsXg1Ws2Jf+g==,type:str]
+    lastmodified: "2026-03-25T11:54:31Z"
+    mac: ENC[AES256_GCM,data:uBd+xzxU7mLwvfGazbwpx2hRXB7saNsnLm5jABm08IAIZZsONkQ8AY9+WMWec9DMRQVWy3jpQbFfqWSaIoa072Z0sDFNWyVavJW6o/oCwI7WbjYXpwqS4DF4Sh/zMfY9sHcO8su9zPRQX98q7Tm/c0xNuBqnZWitEM2c7S3tNlM=,iv:RviopMYe31EoWCC5/GYzCpVaJvobbKNxk3LuDUUD7nc=,tag:J3HXvrKGpWkCl5yM6l/nOg==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type|project|destination|syncPolicy|repoURL|chart|targetRevision|registry|tag|repository)$
     version: 3.12.1


### PR DESCRIPTION
## Problem

When PCS switches the active NAS node, iSCSI sessions break and pods with PVCs get read/write errors. The only fix is restarting all deployments with PVCs.

## Root Cause

The default `replacement_timeout` (120s) expires before PCS failover completes, causing I/O errors to propagate to XFS which force-shuts down the filesystem.

## Changes

### iSCSI Session Tuning (`app-iscsi.sops.yaml`)
- Added `node-db.node.session.timeo.replacement_timeout: "300"` to both iSCSI storage class `node-stage-secret` sections
- This is applied per-session by democratic-csi via `iscsiadm -m node -o update`, overriding the Talos iscsid.conf default — no Talos config change needed
- Gives the initiator 5 minutes to reconnect; I/O stays queued at the SCSI layer during failover

### Justfile Recipe (`justfile`)
- Added `restart-iscsi-pods` recipe to automate rolling restart of all PVC-using deployments
- Serves as fallback for edge cases and as one-time restart to apply the new settings

## After Merge
Run `just restart-iscsi-pods` once to re-stage existing volumes with the new timeout.