### PR TITLE
fix: add ServerSideApply to CRD-installing ArgoCD apps

### DIFF
--- a/kubernetes/infra/cert-manager/app.yaml
+++ b/kubernetes/infra/cert-manager/app.yaml
@@ -48,6 +48,7 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/infra/democratic-csi/app-snapshotter.yaml
+++ b/kubernetes/infra/democratic-csi/app-snapshotter.yaml
@@ -18,6 +18,7 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/infra/node-feature-discovery/app.yaml
+++ b/kubernetes/infra/node-feature-discovery/app.yaml
@@ -17,6 +17,7 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/infra/nvidia-device-plugin/app.yaml
+++ b/kubernetes/infra/nvidia-device-plugin/app.yaml
@@ -18,6 +18,7 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/infra/prometheus-operator/app.yaml
+++ b/kubernetes/infra/prometheus-operator/app.yaml
@@ -49,7 +49,7 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-      - Replace=true
+      - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/enforce: privileged

--- a/kubernetes/infra/tailscale-operator/app.yaml
+++ b/kubernetes/infra/tailscale-operator/app.yaml
@@ -48,6 +48,7 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
## Problem

`node-feature-discovery` (and likely other apps) constantly shows as OutOfSync in ArgoCD.

## Root Cause

Helm charts that install CRDs cause the Kubernetes API server to populate `status` fields (`storedVersions`, `acceptedNames`, `conditions`) after creation. ArgoCD's default client-side apply detects these server-managed fields as drift, reporting constant out-of-sync.

## Fix

Add `ServerSideApply=true` to `syncOptions` for all CRD-installing apps. Server-side apply properly tracks field ownership so controller-managed fields no longer trigger false drift.

### Apps updated
| App | CRDs | Change |
|-----|------|--------|
| **node-feature-discovery** | NodeFeature, NodeFeatureRule, etc. | Added `ServerSideApply=true` |
| **cert-manager** | Certificate, Issuer, etc. | Added `ServerSideApply=true` |
| **nvidia-device-plugin** | GFD CRDs (`gfd.enabled: true`) | Added `ServerSideApply=true` |
| **snapshot-controller** | VolumeSnapshot CRDs | Added `ServerSideApply=true` |
| **tailscale-operator** | Connector, ProxyGroup, etc. | Added `ServerSideApply=true` |
| **prometheus-operator-crds** | Prometheus, ServiceMonitor, etc. | Migrated `Replace=true` → `ServerSideApply=true` |

## Notes
- SSA is the ArgoCD-recommended approach for Helm charts with CRDs
- Only the Helm chart Applications are updated (not `-configs` companion apps which are git-sourced and don't install CRDs)
- After merging, ArgoCD will re-sync once and then remain in sync