### PR TITLE
fix: tune memory requests/limits based on Prometheus metrics

### DIFF
--- a/kubernetes/apps/bazarr/app.yaml
+++ b/kubernetes/apps/bazarr/app.yaml
@@ -66,7 +66,7 @@ spec:
                     cpu: 15m
                     memory: 256Mi
                   limits:
-                    memory: 512Mi
+                    memory: 1Gi
                 securityContext:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true

--- a/kubernetes/apps/mosquitto/app.yaml
+++ b/kubernetes/apps/mosquitto/app.yaml
@@ -91,6 +91,8 @@ spec:
                   readOnlyRootFilesystem: true
                   capabilities: {drop: ["ALL"]}
                 resources:
+                  limits:
+                    memory: 64Mi
                   requests:
                     cpu: 10m
                     memory: 20Mi

--- a/kubernetes/apps/ollama/app.yaml
+++ b/kubernetes/apps/ollama/app.yaml
@@ -62,6 +62,13 @@ spec:
 
         runtimeClassName: nvidia
 
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 16Gi
+
         ollama:
           gpu:
             enabled: true

--- a/kubernetes/apps/plex-auto-languages/app.yaml
+++ b/kubernetes/apps/plex-auto-languages/app.yaml
@@ -114,9 +114,10 @@ spec:
                       - ALL
                 resources:
                   limits:
-                    memory: 256M
+                    memory: 512M
                   requests:
                     cpu: 10m
+                    memory: 128M
 
         persistence:
           config:

--- a/kubernetes/apps/plex/app.yaml
+++ b/kubernetes/apps/plex/app.yaml
@@ -116,6 +116,7 @@ spec:
                 resources:
                   requests:
                     cpu: 100m
+                    memory: 2Gi
                   limits:
                     nvidia.com/gpu: 1
                     memory: 9248M

--- a/kubernetes/apps/sonarr/app.yaml
+++ b/kubernetes/apps/sonarr/app.yaml
@@ -76,7 +76,7 @@ spec:
                     cpu: 20m
                     memory: 384Mi
                   limits:
-                    memory: 2Gi
+                    memory: 3Gi
                 securityContext:
                   allowPrivilegeEscalation: false
                   readOnlyRootFilesystem: true

--- a/kubernetes/infra/prometheus-operator/app.yaml
+++ b/kubernetes/infra/prometheus-operator/app.yaml
@@ -197,6 +197,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 512M
               limits:
                 memory: 2000M
             retention: 14d


### PR DESCRIPTION
## Summary
Fixes OOM kill on `plex-auto-languages` and tunes memory configs for 6 other apps based on 7-day peak usage from Prometheus.

## Changes

| App | Change | Reason (7-day peak) |
|---|---|---|
| **plex-auto-languages** | 256M→512M limit, +128M request | **OOM killed** (244/256M = 95%) |
| **bazarr** | 512Mi→1Gi limit | Near-OOM (511/512Mi = 99.8%) |
| **sonarr** | 2Gi→3Gi limit | Near-OOM (1864/2048Mi = 91%) |
| **plex** | +2Gi memory request | Missing request (peak ~6Gi) |
| **prometheus** | +512M memory request | Missing request (peak ~898MiB) |
| **mosquitto** | +64Mi memory limit | No limit at all |
| **ollama** | +128Mi req / 16Gi limit | No resources defined |

## Notes
- CPU limits intentionally not set (avoids throttling — best practice)
- All values derived from live Prometheus `container_memory_working_set_bytes` 7-day max