### PR TITLE
fix: disable NFD post-delete hooks causing ArgoCD drift

### DIFF
--- a/kubernetes/infra/node-feature-discovery/app.yaml
+++ b/kubernetes/infra/node-feature-discovery/app.yaml
@@ -31,6 +31,8 @@ spec:
     targetRevision: 0.18.3
     helm:
       valuesObject:
+        postDeleteCleanup: false
+
         master:
           config:
             extraLabelNs:


### PR DESCRIPTION
## Root Cause

The `node-feature-discovery` Helm chart has `postDeleteCleanup: true` by default. This renders `helm.sh/hook: post-delete` resources (Job, ServiceAccount, ClusterRole, ClusterRoleBinding). When ArgoCD detects these hooks, it adds `post-delete-finalizer.argocd.argoproj.io` entries to the Application resource.

Since those finalizers aren't defined in git, the parent `infra` app-of-apps permanently sees the NFD Application as OutOfSync.

## Fix

Set `postDeleteCleanup: false` in the chart values. The post-delete cleanup job's purpose is to remove NFD node labels when uninstalling — not needed in a GitOps-managed cluster where ArgoCD handles lifecycle.

## Why the SSA fix from #431 didn't help

PR #431 added `ServerSideApply=true` to the NFD **child** app to fix CRD status field drift. This is a different issue — the drift is on the Application **resource itself** (metadata.finalizers), not on the resources the app manages.