### PR TITLE
fix: add NFD post-delete finalizers to match ArgoCD runtime state

### DIFF
--- a/kubernetes/infra/node-feature-discovery/app.yaml
+++ b/kubernetes/infra/node-feature-discovery/app.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+    - post-delete-finalizer.argocd.argoproj.io
+    - post-delete-finalizer.argocd.argoproj.io/cleanup
   annotations:
     argocd.argoproj.io/sync-wave: "-4"
 spec:


### PR DESCRIPTION
## Root Cause

The NFD Helm chart has `postDeleteCleanup: true` (default), which renders `helm.sh/hook: post-delete` resources (a cleanup Job that strips NFD node labels on uninstall). When ArgoCD detects post-delete hooks in a child app, it adds `post-delete-finalizer` entries to that Application's metadata so the hooks run before deletion.

Since the NFD Application manifest in git didn't include these finalizers, the parent `infra` app detected metadata drift → permanent OutOfSync.

## Fix

Declare the ArgoCD-managed post-delete finalizers in the NFD Application manifest so git matches the runtime state. This is targeted to NFD specifically (the only chart with post-delete hooks).

## Why not other approaches
- **`postDeleteCleanup: false`**: Would break legitimate cleanup of NFD node labels on uninstall
- **`ignoreDifferences` on parent**: Too broad — hides all finalizer drift across all child apps
- **SSA on parent**: Overkill for this specific issue