### PR TITLE
fix: haproxy rolling update deadlock with pod anti-affinity

### DIFF
--- a/kubernetes/bootstrap/argocd/kustomization.yaml
+++ b/kubernetes/bootstrap/argocd/kustomization.yaml
@@ -21,3 +21,7 @@ patches:
     target:
       kind: Deployment
       name: argocd-repo-server
+  - path: patches/argocd-redis-ha-haproxy.yaml
+    target:
+      kind: Deployment
+      name: argocd-redis-ha-haproxy

--- a/kubernetes/bootstrap/argocd/patches/argocd-redis-ha-haproxy.yaml
+++ b/kubernetes/bootstrap/argocd/patches/argocd-redis-ha-haproxy.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-redis-ha-haproxy
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1


### PR DESCRIPTION
Upstream `argocd-redis-ha-haproxy` uses `maxSurge=25%` (→1) + `maxUnavailable=25%` (→0 for 3 replicas). With required pod anti-affinity on a 3-node cluster, the surge pod can never schedule → permanent rollout deadlock.

Fix: `maxSurge=0, maxUnavailable=1` — removes one old pod before creating a new one.