### PR TITLE
fix: use --core mode in argocd prune recipe

### DIFF
--- a/kubernetes/bootstrap/argocd/mod.just
+++ b/kubernetes/bootstrap/argocd/mod.just
@@ -12,9 +12,12 @@ prune:
     echo "==> Scanning for orphaned resources..."
 
     # Managed resources (authoritative: the ArgoCD self-managing Application)
-    if ! argocd app resources argocd -o json > "$TMPDIR/managed.json" 2>/dev/null; then
-      echo "ERROR: Cannot query ArgoCD. Is the 'argocd' CLI configured?"
-      echo "  Try: argocd login --core"
+    if ! argocd app resources argocd -o json --core \
+         --kube-context "$(kubectl config current-context)" \
+         > "$TMPDIR/managed.json" 2>/dev/null; then
+      echo "ERROR: Cannot query ArgoCD."
+      echo "  Ensure your kubeconfig context namespace is 'argocd':"
+      echo "    kubectl config set-context --current --namespace=argocd"
       exit 1
     fi
 


### PR DESCRIPTION
The `just argocd prune` recipe now uses `argocd --core` to talk directly to the Kubernetes API instead of requiring an ArgoCD server connection. Includes a clear error message if the kubeconfig context namespace isn't set to `argocd`.