### PR TITLE
feat: add editor and developer tooling config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.yaml linguist-detectable linguist-language=YAML
+*.yml linguist-detectable linguist-language=YAML
+*.just linguist-detectable linguist-language=Just
+*.json5 linguist-detectable linguist-language=JSON5
+*.sops.yaml linguist-generated

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "redhat.vscode-yaml",
+    "signageos.signageos-vscode-sops",
+    "redhat.ansible",
+    "skellock.just"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "yaml.schemas": {
+    "kubernetes": [
+      "kubernetes/**/*.yaml",
+      "kubernetes/**/*.yml"
+    ]
+  },
+  "files.associations": {
+    "*.yaml": "yaml",
+    "*.yml": "yaml",
+    "*.sops.yaml": "yaml"
+  },
+  "editor.formatOnSave": false,
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml",
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  }
+}


### PR DESCRIPTION
Add editor configuration files for consistent development experience:

- **`.editorconfig`** — enforces 2-space indentation, LF line endings, UTF-8 encoding, and trailing whitespace trimming across all editors
- **`.gitattributes`** — configures GitHub Linguist language detection for `.yaml`, `.yml`, `.just`, and `.json5` files; marks SOPS files as generated
- **`.vscode/settings.json`** — YAML language server with Kubernetes schema validation for inline manifest checking
- **`.vscode/extensions.json`** — recommends YAML, SOPS, Ansible, and Just extensions