### PR TITLE
feat: add YAML formatting and tool version management

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,12 @@
+[tools]
+"aqua:casey/just" = "1.48.1"
+"aqua:kubernetes/kubectl" = "1.35.3"
+"aqua:jqlang/jq" = "1.7.1"
+"aqua:argoproj/argo-cd" = "3.3.6"
+"aqua:vmware-tanzu/velero" = "1.15.3"
+"aqua:getsops/sops" = "3.12.2"
+"aqua:google/yamlfmt" = "0.21.0"
+
+[env]
+# Ensure just uses unstable features (needed for mod support)
+JUST_UNSTABLE = "1"

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,19 @@
+---
+doublestar: true
+formatter:
+  type: basic
+  drop_merge_tag: true
+  eof_newline: true
+  include_document_start: true
+  indent: 2
+  indentless_arrays: false
+  line_ending: lf
+  retain_line_breaks_single: true
+  scan_folded_as_literal: true
+  trim_trailing_whitespace: true
+exclude:
+  # SOPS-encrypted files
+  - "**/*.sops.yaml"
+  - "**/*.sops.yml"
+  # Git submodule
+  - "ansible/roles/bind9/**"


### PR DESCRIPTION
Add YAML auto-formatting and local tool management:

- **`.yamlfmt.yaml`** — yamlfmt configuration for auto-formatting YAML files (2-space indent, document start markers, block arrays, LF line endings). Excludes SOPS-encrypted files and the bind9 submodule.
- **`.mise.toml`** — mise tool version manager with pinned versions:

| Tool | Package |
|------|---------|
| just | `aqua:casey/just` |
| kubectl | `aqua:kubernetes/kubectl` |
| jq | `aqua:jqlang/jq` |
| argocd | `aqua:argoproj/argo-cd` |
| velero | `aqua:vmware-tanzu/velero` |
| sops | `aqua:getsops/sops` |
| yamlfmt | `aqua:google/yamlfmt` |

Versions are pinned and Renovate will manage bumps, with CLI tools grouped alongside their deployed counterparts (argocd CLI + ArgoCD server, sops CLI + KSOPS, velero CLI + Velero chart).

Run `mise install` to set up. Requires `eval "$(mise activate zsh)"` in `.zshrc` (or guard with `command -v mise &>/dev/null &&`).