### PR TITLE
docs: enhance README with Kromgo badges and tech stack

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+---
+# Disable line length - badge URLs and tech descriptions are naturally long
+MD013: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # 🏠 Homelab
 
-[![CI](https://img.shields.io/github/actions/workflow/status/mpeterson/homelab/ci.yaml?branch=main&style=flat-square&logo=github&label=CI)](https://github.com/mpeterson/homelab/actions/workflows/ci.yaml)
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fstats-k8s.peterson.com.ar%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=orange&label=talos)](https://talos.dev)&nbsp;
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fstats-k8s.peterson.com.ar%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=k8s)](https://kubernetes.io)
+
+[![Age](https://stats-k8s.peterson.com.ar/cluster_age_days?format=badge)](https://github.com/kashalls/kromgo/)&nbsp;
+[![Nodes](https://stats-k8s.peterson.com.ar/cluster_node_count?format=badge)](https://github.com/kashalls/kromgo/)&nbsp;
+[![Pods](https://stats-k8s.peterson.com.ar/cluster_pod_count?format=badge)](https://github.com/kashalls/kromgo/)&nbsp;
+[![CPU](https://stats-k8s.peterson.com.ar/cluster_cpu_usage?format=badge)](https://github.com/kashalls/kromgo/)&nbsp;
+[![Memory](https://stats-k8s.peterson.com.ar/cluster_memory_usage?format=badge)](https://github.com/kashalls/kromgo/)&nbsp;
+[![Alerts](https://stats-k8s.peterson.com.ar/cluster_alert_count?format=badge)](https://github.com/kashalls/kromgo/)
+
+---
+
+[![Lint](https://img.shields.io/github/actions/workflow/status/mpeterson/homelab/lint.yaml?branch=main&style=flat-square&logo=github&label=Lint)](https://github.com/mpeterson/homelab/actions/workflows/lint.yaml)
 [![License](https://img.shields.io/github/license/mpeterson/homelab?style=flat-square)](LICENSE)
 [![Last Commit](https://img.shields.io/github/last-commit/mpeterson/homelab?style=flat-square)](https://github.com/mpeterson/homelab/commits/main)
 [![Stars](https://img.shields.io/github/stars/mpeterson/homelab?style=flat-square)](https://github.com/mpeterson/homelab/stargazers)
@@ -10,7 +22,7 @@ Kubernetes-based homelab running on bare-metal, managed entirely through GitOps.
 ## Tech Stack
 
 | Component | Technology |
-|-----------|-----------|
+| --- | --- |
 | OS | [Talos Linux](https://www.talos.dev/) |
 | GitOps | [ArgoCD](https://argo-cd.readthedocs.io/) |
 | CNI | [Cilium](https://cilium.io/) (BGP, Gateway API) |
@@ -25,7 +37,7 @@ Kubernetes-based homelab running on bare-metal, managed entirely through GitOps.
 
 ## Repository Structure
 
-```
+```text
 📂 ansible/          # Ansible playbooks and roles for node provisioning
 📂 docs/             # Documentation
 📂 hack/             # Ad-hoc manifests and utilities


### PR DESCRIPTION
Overhaul the README with dynamic cluster stats and project documentation.

**Cluster stats** (via [Kromgo](https://github.com/kashalls/kromgo) at `stats-k8s.peterson.com.ar`):

| Badge | Value |
|---|---|
| Talos | v1.10.4 |
| Kubernetes | v1.32.4 |
| Nodes | 6 (ready only) |
| Pods | 101 |
| CPU | 4.3% (green/orange/red thresholds) |
| Memory | 51.8% (green/orange/red thresholds) |
| Age | 275 days |
| Alerts | 0 (excludes Watchdog) |

**GitHub badges:** Lint CI status, license, last commit, stars

**Content:** Tech stack table with links, repository structure overview, getting started (`just --list`), license reference.