### PR TITLE
fix: add file-type filters to lint jobs and harden checkouts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,11 +14,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Get changed files
+        id: changed-files
+        uses: bjw-s-labs/action-changed-files@015416e33c709af88f84a4496f4030c1f0ef212e  # v0.5.0
+        with:
+          patterns: |-
+            **/*.yaml
+            **/*.yml
 
       - name: Setup uv
+        if: steps.changed-files.outputs.changed_files != '[]'
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Run yamllint
+        if: steps.changed-files.outputs.changed_files != '[]'
         run: uvx yamllint --strict --format github -c .yamllint.yaml .
 
   jsonlint:
@@ -27,8 +39,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Get changed files
+        id: changed-files
+        uses: bjw-s-labs/action-changed-files@015416e33c709af88f84a4496f4030c1f0ef212e  # v0.5.0
+        with:
+          patterns: |-
+            **/*.json
+            **/*.json5
 
       - name: Validate JSON/JSON5 files
+        if: steps.changed-files.outputs.changed_files != '[]'
         run: |
           status=0
           while IFS= read -r file; do
@@ -45,11 +68,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Get changed files
+        id: changed-files
+        uses: bjw-s-labs/action-changed-files@015416e33c709af88f84a4496f4030c1f0ef212e  # v0.5.0
+        with:
+          patterns: |-
+            .github/workflows/*.yaml
+            .github/workflows/*.yml
 
       - name: Install actionlint
+        if: steps.changed-files.outputs.changed_files != '[]'
         run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
       - name: Run actionlint
+        if: steps.changed-files.outputs.changed_files != '[]'
         run: ./actionlint -color
 
   markdownlint:
@@ -58,19 +93,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Get changed files
+        id: changed-files
+        uses: bjw-s-labs/action-changed-files@015416e33c709af88f84a4496f4030c1f0ef212e  # v0.5.0
+        with:
+          patterns: |-
+            **/*.md
 
       - name: Run markdownlint
+        if: steps.changed-files.outputs.changed_files != '[]'
         uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9  # v23.0.0
 
   lint-success:
     name: All linters passed
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [yamllint, jsonlint, actionlint, markdownlint]
     runs-on: ubuntu-latest
     steps:
       - name: Check lint results
+        if: ${{ contains(needs.*.result, 'failure') }}
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-            echo "::error::One or more lint jobs failed"
-            exit 1
-          fi
+          echo "::error::One or more lint jobs failed"
+          exit 1

--- a/.github/workflows/sops-integrity-check.yaml
+++ b/.github/workflows/sops-integrity-check.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check SOPS files were properly re-encrypted
         run: |


### PR DESCRIPTION
**Changes:**

- Each lint job uses `bjw-s-labs/action-changed-files` to detect relevant file changes and skips the lint step if no matching files were modified:
  - **YAML**: `**/*.yaml`, `**/*.yml`
  - **JSON**: `**/*.json`, `**/*.json5`
  - **Actions**: `.github/workflows/*.yaml`, `.github/workflows/*.yml`
  - **Markdown**: `**/*.md`
- Add `persist-credentials: false` to all checkout steps (except `update-xseed.yaml` which needs credentials to push) to prevent third-party actions from accessing the GITHUB_TOKEN