### PR TITLE
chore: enable mise auto_install per-project

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,6 @@
+[settings]
+auto_install = true
+
 [tools]
 "aqua:casey/just" = "1.48.1"
 "aqua:kubernetes/kubectl" = "1.35.3"


### PR DESCRIPTION
Add `[settings] auto_install = true` to `.mise.toml` so missing tool versions are automatically installed when entering the repo directory.

This is a per-project setting — it won't affect other repos or global mise behavior.