### PR TITLE
fix: correct Renovate local preset paths and add config validation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -107,10 +107,22 @@ jobs:
         if: steps.changed-files.outputs.changed_files != '[]'
         uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9  # v23.0.0
 
+  renovatelint:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Renovate config
+        run: npx --yes --package renovate@latest -- renovate-config-validator --strict
+
   lint-success:
     name: All linters passed
     if: ${{ !cancelled() }}
-    needs: [yamllint, jsonlint, actionlint, markdownlint]
+    needs: [yamllint, jsonlint, actionlint, markdownlint, renovatelint]
     runs-on: ubuntu-latest
     steps:
       - name: Check lint results

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,9 +4,9 @@
     "config:best-practices",
     ":disableRateLimiting",
     // Local modular configs
-    "local>michelp/homelab//.renovate/autoMerge.json5",
-    "local>michelp/homelab//.renovate/groups.json5",
-    "local>michelp/homelab//.renovate/customManagers.json5",
+    "local>//.renovate/autoMerge.json5",
+    "local>//.renovate/groups.json5",
+    "local>//.renovate/customManagers.json5",
   ],
   timezone: "Asia/Jerusalem",
   schedule: ["after 2am and before 7am"],


### PR DESCRIPTION
**Fixes:**
- Fix `extends` preset syntax — use `local>//.renovate/...` instead of `local>michelp/homelab//.renovate/...`

**Additions:**
- Add `Lint / Renovate` job that runs `renovate-config-validator --strict` on PRs touching `renovate.json5` or `.renovate/**` — prevents this kind of breakage in the future

Fixes #470