### PR TITLE
fix: use github> preset syntax for Renovate modular configs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,9 +4,9 @@
     "config:best-practices",
     ":disableRateLimiting",
     // Local modular configs
-    "local>//.renovate/autoMerge.json5",
-    "local>//.renovate/groups.json5",
-    "local>//.renovate/customManagers.json5",
+    "github>mpeterson/homelab//.renovate/autoMerge.json5",
+    "github>mpeterson/homelab//.renovate/groups.json5",
+    "github>mpeterson/homelab//.renovate/customManagers.json5",
   ],
   timezone: "Asia/Jerusalem",
   schedule: ["after 2am and before 7am"],


### PR DESCRIPTION
The `local>` preset syntax doesn't work with the Renovate GitHub App for same-repo file references. Switch to `github>mpeterson/homelab//` which the App can resolve.

Fixes #474