### PR TITLE
fix: add kustomization.yaml for Kromgo configs

### DIFF
--- a/kubernetes/infra/kromgo/kustomization.yaml
+++ b/kubernetes/infra/kromgo/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - config.yaml

--- a/kubernetes/infra/kustomization.yaml
+++ b/kubernetes/infra/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - cilium/app.yaml
   - cert-manager/app.yaml
   - democratic-csi/app-snapshotter.yaml
+  - kromgo/app.yaml
   - metrics-server/app.yaml
   - node-feature-discovery/app.yaml
   - nvidia-device-plugin/app.yaml


### PR DESCRIPTION
The Kromgo deployment from #478 was missing two pieces:

- Add `kustomization.yaml` in `kubernetes/infra/kromgo/` so ArgoCD can process the configs directory and create the ConfigMap
- Add `kromgo/app.yaml` to `kubernetes/infra/kustomization.yaml` so ArgoCD discovers the Kromgo Application