### PR TITLE
fix: correct Kromgo Helm chart repository URL

### DIFF
--- a/kubernetes/infra/kromgo/app.yaml
+++ b/kubernetes/infra/kromgo/app.yaml
@@ -59,7 +59,7 @@ spec:
       prune: true
 
   source:
-    repoURL: https://ghcr.io/bjw-s-labs/helm
+    repoURL: https://bjw-s-labs.github.io/helm-charts
     chart: app-template
     targetRevision: 4.6.2
 


### PR DESCRIPTION
Fix ArgoCD deployment failure — use `https://bjw-s-labs.github.io/helm-charts` (GitHub Pages Helm repo) instead of `https://ghcr.io/bjw-s-labs/helm` (OCI registry, not supported as a plain Helm repo URL by ArgoCD).