### PR TITLE
fix: use queries that match available Prometheus metrics

### DIFF
--- a/kubernetes/infra/kromgo/config.yaml
+++ b/kubernetes/infra/kromgo/config.yaml
@@ -12,71 +12,21 @@ data:
       size: 12
 
     metrics:
-      - name: talos_version
-        query: label_replace(node_os_info{name="Talos"}, "version_id", "$1", "version_id", "v(.+)")
-        label: version_id
-        title: Talos
-
       - name: kubernetes_version
-        query: label_replace(kubernetes_build_info{service="kubernetes"}, "git_version", "$1", "git_version", "v(.+)")
+        query: kubernetes_build_info{service="kubernetes"}
         label: git_version
         title: Kubernetes
 
       - name: cluster_node_count
-        query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
+        query: count(kubelet_node_name)
         title: Nodes
 
       - name: cluster_pod_count
-        query: sum(kube_pod_status_phase{phase="Running"})
+        query: sum(kubelet_running_pods)
         title: Pods
 
-      - name: cluster_cpu_usage
-        query: round(avg(instance:node_cpu_utilisation:rate5m{kubernetes_node!=""}) * 100, 0.1)
-        title: CPU
-        suffix: "%"
-        colors:
-          - color: "green"
-            min: 0
-            max: 35
-          - color: "orange"
-            min: 36
-            max: 75
-          - color: "red"
-            min: 76
-            max: 9999
-
-      - name: cluster_memory_usage
-        query: round(sum(node_memory_MemTotal_bytes{kubernetes_node!=""} - node_memory_MemAvailable_bytes{kubernetes_node!=""}) / sum(node_memory_MemTotal_bytes{kubernetes_node!=""}) * 100, 0.1)
-        title: Memory
-        suffix: "%"
-        colors:
-          - color: "green"
-            min: 0
-            max: 35
-          - color: "orange"
-            min: 36
-            max: 75
-          - color: "red"
-            min: 76
-            max: 9999
-
-      - name: cluster_age_days
-        query: round((time() - max(kube_node_created) ) / 86400)
-        title: Age
-        suffix: "d"
-        colors:
-          - color: "green"
-            min: 0
-            max: 180
-          - color: "orange"
-            min: 181
-            max: 360
-          - color: "red"
-            min: 361
-            max: 9999
-
       - name: cluster_alert_count
-        query: count(ALERTS{alertstate="firing"}) - 1
+        query: count(ALERTS{alertstate="firing",alertname!="Watchdog"}) OR vector(0)
         title: Alerts
         colors:
           - color: "green"


### PR DESCRIPTION
Queried Prometheus directly to find what metrics are actually available:

**Available** (kept):
- `kubernetes_build_info` → K8s version (v1.32.4) ✅
- `kubelet_node_name` → node count (6 nodes) ✅
- `kubelet_running_pods` → pod count (94 pods) ✅
- `ALERTS` → alert count (Watchdog excluded) ✅

**Not available** (removed):
- `talos_version` — no Talos-specific Prometheus metric
- `cluster_cpu_usage` — node-exporter only runs on Unraid, not Talos nodes
- `cluster_memory_usage` — same reason
- `cluster_age_days` — `kube_node_created` requires kube-state-metrics which isn't deployed

These can be added back if kube-state-metrics and node-exporter are deployed on the Talos nodes.