### PR TITLE
chore: add .local to gitignore for local planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 inventories
 hack
+.local


### PR DESCRIPTION
Adds `.local/` to `.gitignore` so local planning documents (upgrade plans, research notes) are not tracked by git.

This directory is used for storing local-only documentation like upgrade plans and related research.