### PR TITLE
fix: support Docker digest pinning for argocd-diff-preview

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -19,8 +19,9 @@
         "/kubernetes/bootstrap/argocd/mod\\.just$/",
       ],
       matchStrings: [
-        "# renovate: datasource=docker depName=(?<depName>[^\\s]+)\\n_argocd_diff_preview_version := \"(?<currentValue>[^\"]+)\"",
+        "# renovate: datasource=docker depName=(?<depName>[^\\s]+)\\n_argocd_diff_preview_version := \"(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[^\"]+))?\"",
       ],
+      autoReplaceStringTemplate: "# renovate: datasource=docker depName={{{depName}}}\n_argocd_diff_preview_version := \"{{{newValue}}}@{{{newDigest}}}\"",
       datasourceTemplate: "docker",
     },
     {


### PR DESCRIPTION
Fixes Renovate 'Error updating branch: update failure' for the `dagandersen/argocd-diff-preview` Docker image.

The custom regex manager now supports Docker digest pinning by:
1. Capturing the optional `@sha256:...` digest via `currentDigest` group
2. Using `autoReplaceStringTemplate` to output `tag@sha256:digest` format

After Renovate pins the digest, the version in `mod.just` will look like:
```
_argocd_diff_preview_version := "v0.2.2@sha256:c1daee4c0a132..."
```

Docker natively supports `image:tag@sha256:digest` — it pulls by digest (secure) while keeping the tag for readability.