### PR TITLE
fix: use cronJob for Hubble TLS cert generation

### DIFF
--- a/kubernetes/infra/cilium/values.yaml
+++ b/kubernetes/infra/cilium/values.yaml
@@ -51,6 +51,9 @@ gatewayAPI:
 hubble:
   relay:
     enabled: true
+  tls:
+    auto:
+      method: cronJob
   ui:
     enabled: true
 


### PR DESCRIPTION
Switches `hubble.tls.auto.method` from `helm` (default) to `cronJob`.

The `helm` method generates new TLS certs (cilium-ca, hubble-server-certs, hubble-relay-client-certs) on every `helm template` render. Since ArgoCD uses `helm template` on each sync cycle, these three secrets are perpetually OutOfSync.

`cronJob` delegates cert generation to a Kubernetes CronJob that runs inside the cluster, so certs are stable across renders. It is self-contained (no cert-manager dependency) and handles automatic rotation.