### PR TITLE
fix: ignore server-defaulted fields causing OutOfSync

### DIFF
--- a/kubernetes/bootstrap/argocd/patches/argocd-cm.yaml
+++ b/kubernetes/bootstrap/argocd/patches/argocd-cm.yaml
@@ -6,6 +6,13 @@ metadata:
 data:
   application.resourceTrackingMethod: annotation+label
   kustomize.buildOptions: "--enable-alpha-plugins --enable-exec"
+  # Prometheus Operator defaults `action: replace` on ServiceMonitor relabelings.
+  # Helm templates often omit it (since replace is the default), causing a
+  # perpetual diff between rendered and live state.
+  resource.customizations.ignoreDifferences.monitoring.coreos.com_ServiceMonitor: |
+    jqPathExpressions:
+    - .spec.endpoints[]?.relabelings[]?.action
+    - .spec.endpoints[]?.metricRelabelings[]?.action
   resource.exclusions: |
     ### Network resources created by the Kubernetes control plane
     - apiGroups:

--- a/kubernetes/infra/cilium/app.yaml
+++ b/kubernetes/infra/cilium/app.yaml
@@ -25,6 +25,16 @@ spec:
       selfHeal: true
       prune: false
 
+  # Cilium's Helm template renders nodePort as empty on cilium-ingress Service
+  # ports, letting Kubernetes auto-assign values. This creates a perpetual diff
+  # between the rendered (empty) and live (assigned) state.
+  ignoreDifferences:
+    - group: ""
+      kind: Service
+      name: cilium-ingress
+      jqPathExpressions:
+        - .spec.ports[]?.nodePort
+
   sources:
     - repoURL: https://helm.cilium.io
       chart: cilium


### PR DESCRIPTION
Two ArgoCD OutOfSync issues caused by server-defaulted fields not present in Helm templates:

**App-level** (`kubernetes/infra/cilium/app.yaml`):
- Cilium's chart renders `nodePort:` as empty on `cilium-ingress` Service ports, letting Kubernetes auto-assign values. The rendered (empty) vs live (assigned) diff is perpetual.
- Fix: `ignoreDifferences` with `jqPathExpressions` on `.spec.ports[]?.nodePort`, scoped to `cilium-ingress` only.

**Global** (`argocd-cm.yaml`):
- Prometheus Operator defaults `action: replace` on ServiceMonitor relabelings. Helm templates omit it (since `replace` is the default), causing a perpetual diff on any ServiceMonitor.
- Fix: `resource.customizations.ignoreDifferences.monitoring.coreos.com_ServiceMonitor` covering `.spec.endpoints[].relabelings[].action` and `.spec.endpoints[].metricRelabelings[].action`.

Ref: [ArgoCD diffing docs](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/), [Cilium ArgoCD troubleshooting](https://docs.cilium.io/en/latest/configuration/argocd-issues.html)