### PR TITLE
revert: upgrade Cilium to v1.18.8

### DIFF
--- a/kubernetes/bootstrap/mod.just
+++ b/kubernetes/bootstrap/mod.just
@@ -4,7 +4,7 @@ set shell := ['bash', '-euo', 'pipefail', '-c']
 bootstrap_dir := source_directory()
 
 # renovate: datasource=helm registryUrl=https://helm.cilium.io depName=cilium
-_cilium_chart_version := "1.18.8"
+_cilium_chart_version := "1.17.3"
 
 [private]
 _require *tools:

--- a/kubernetes/infra/cilium/app.yaml
+++ b/kubernetes/infra/cilium/app.yaml
@@ -39,7 +39,7 @@ spec:
     - repoURL: https://helm.cilium.io
       chart: cilium
       # renovate: datasource=helm registryUrl=https://helm.cilium.io depName=cilium
-      targetRevision: 1.18.8
+      targetRevision: 1.17.3
       helm:
         valueFiles:
           - $values/kubernetes/infra/cilium/values.yaml

--- a/kubernetes/infra/cilium/bgp-control-plane.yaml
+++ b/kubernetes/infra/cilium/bgp-control-plane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cilium.io/v2
+apiVersion: cilium.io/v2alpha1
 kind: CiliumBGPClusterConfig
 metadata:
   name: cilium-bgp
@@ -18,7 +18,7 @@ spec:
           peerConfigRef:
             name: "cilium-peer"
 ---
-apiVersion: cilium.io/v2
+apiVersion: cilium.io/v2alpha1
 kind: CiliumBGPPeerConfig
 metadata:
   name: cilium-peer
@@ -33,7 +33,7 @@ spec:
         matchLabels:
           advertise: "bgp"
 ---
-apiVersion: cilium.io/v2
+apiVersion: cilium.io/v2alpha1
 kind: CiliumBGPAdvertisement
 metadata:
   name: bgp-advertisements
@@ -49,7 +49,7 @@ spec:
         matchExpressions:
           - {key: gateway.networking.k8s.io/gateway-name, operator: NotIn, values: ['never-used-value']}
 ---
-apiVersion: "cilium.io/v2"
+apiVersion: "cilium.io/v2alpha1"
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: lb-ip-pool

--- a/kubernetes/infra/cilium/values.yaml
+++ b/kubernetes/infra/cilium/values.yaml
@@ -11,8 +11,6 @@ bandwidthManager:
   bbr: true
   enabled: true
 
-upgradeCompatibility: "1.17"
-
 bgpControlPlane:
   enabled: true
 
@@ -77,8 +75,7 @@ loadBalancer:
   algorithm: maglev
   mode: dsr
 
-localRedirectPolicies:
-  enabled: true
+localRedirectPolicy: true
 
 operator:
   dashboards:


### PR DESCRIPTION
Reverts #518. Cilium v1.18.8 crashes on CP nodes with BPF dead code elimination probe failure. Rolling back to v1.17.3.