### PR TITLE
feat: upgrade Cilium to v1.18.7

### DIFF
--- a/kubernetes/bootstrap/mod.just
+++ b/kubernetes/bootstrap/mod.just
@@ -4,7 +4,7 @@ set shell := ['bash', '-euo', 'pipefail', '-c']
 bootstrap_dir := source_directory()
 
 # renovate: datasource=helm registryUrl=https://helm.cilium.io depName=cilium
-_cilium_chart_version := "1.17.3"
+_cilium_chart_version := "1.18.7"
 
 [private]
 _require *tools:

--- a/kubernetes/infra/cilium/app.yaml
+++ b/kubernetes/infra/cilium/app.yaml
@@ -39,7 +39,7 @@ spec:
     - repoURL: https://helm.cilium.io
       chart: cilium
       # renovate: datasource=helm registryUrl=https://helm.cilium.io depName=cilium
-      targetRevision: 1.17.3
+      targetRevision: 1.18.7
       helm:
         valueFiles:
           - $values/kubernetes/infra/cilium/values.yaml

--- a/kubernetes/infra/cilium/bgp-control-plane.yaml
+++ b/kubernetes/infra/cilium/bgp-control-plane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumBGPClusterConfig
 metadata:
   name: cilium-bgp
@@ -18,7 +18,7 @@ spec:
           peerConfigRef:
             name: "cilium-peer"
 ---
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumBGPPeerConfig
 metadata:
   name: cilium-peer
@@ -33,7 +33,7 @@ spec:
         matchLabels:
           advertise: "bgp"
 ---
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumBGPAdvertisement
 metadata:
   name: bgp-advertisements
@@ -49,7 +49,7 @@ spec:
         matchExpressions:
           - {key: gateway.networking.k8s.io/gateway-name, operator: NotIn, values: ['never-used-value']}
 ---
-apiVersion: "cilium.io/v2alpha1"
+apiVersion: "cilium.io/v2"
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: lb-ip-pool

--- a/kubernetes/infra/cilium/values.yaml
+++ b/kubernetes/infra/cilium/values.yaml
@@ -11,6 +11,8 @@ bandwidthManager:
   bbr: true
   enabled: true
 
+upgradeCompatibility: "1.17"
+
 bgpControlPlane:
   enabled: true
 
@@ -75,7 +77,8 @@ loadBalancer:
   algorithm: maglev
   mode: dsr
 
-localRedirectPolicy: true
+localRedirectPolicies:
+  enabled: true
 
 operator:
   dashboards:


### PR DESCRIPTION
Upgrades Cilium from v1.17.3 to v1.18.7.

## Changes

- `targetRevision`: 1.17.3 → 1.18.7 (app.yaml + bootstrap mod.just)
- `upgradeCompatibility: "1.17"` added to values (per [upgrade docs](https://docs.cilium.io/en/v1.18/operations/upgrade/))
- BGP CRD apiVersions: `cilium.io/v2alpha1` → `cilium.io/v2` (v2alpha1 deprecated in 1.18)
- `localRedirectPolicy` → `localRedirectPolicies.enabled` (deprecated in 1.18)

## Why v1.18.7

- **v1.18.8**: BPF dead code elimination probe regression — crashes on startup ([cilium/cilium#44967](https://github.com/cilium/cilium/issues/44967)). We hit this on CP nodes.
- **v1.19.x**: eBPF verifier bug on kernel 6.18.x kills networking with Gateways/LB IPAM ([cilium/cilium#44216](https://github.com/cilium/cilium/issues/44216#issuecomment-4095229890)).
- **v1.18.7**: Latest safe release. Confirmed working by several people.
