### PR TITLE
feat: track cilium-cli in mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -11,6 +11,7 @@ auto_install = true
 "aqua:google/yamlfmt" = "0.21.0"
 "aqua:kubernetes-sigs/kustomize" = "5.8.1"
 "aqua:helm/helm" = "3.20.1"
+"aqua:cilium/cilium-cli" = "0.19.2"
 "aqua:mikefarah/yq" = "4.52.5"
 "aqua:google/go-containerregistry" = "0.21.3"
 "aqua:rhysd/actionlint" = "1.7.11"

--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -52,6 +52,11 @@
       groupName: "cilium",
     },
     {
+      description: "Group Cilium CLI (mise) with Cilium deployment",
+      matchPackageNames: ["aqua:cilium/cilium-cli"],
+      groupName: "cilium",
+    },
+    {
       description: "Group Gateway API CRDs with Cilium (Cilium dependency)",
       matchPackageNames: ["kubernetes-sigs/gateway-api"],
       groupName: "gateway-api",


### PR DESCRIPTION
Adds `cilium-cli` v0.19.2 to `.mise.toml` and groups it with Cilium deployment in Renovate.

Follows the same pattern as ArgoCD CLI, Velero CLI, and SOPS CLI.