### PR TITLE
fix(ci): add Renovate version coupling constraints

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -57,9 +57,19 @@
       groupName: "cilium",
     },
     {
-      description: "Group Gateway API CRDs with Cilium (Cilium dependency)",
+      description: "Group Gateway API CRDs (Cilium dependency)",
       matchPackageNames: ["kubernetes-sigs/gateway-api"],
       groupName: "gateway-api",
+    },
+    {
+      description: "Group Kustomize (mise) with ArgoCD — must match ArgoCD bundled version",
+      matchPackageNames: ["aqua:kubernetes-sigs/kustomize"],
+      groupName: "argocd",
+    },
+    {
+      description: "Group Helm (mise) with ArgoCD — should stay close to ArgoCD bundled version",
+      matchPackageNames: ["aqua:helm/helm"],
+      groupName: "argocd",
     },
     {
       description: "Group SOPS CLI (mise) with KSOPS",

--- a/renovate.json5
+++ b/renovate.json5
@@ -47,5 +47,33 @@
       matchPackageNames: ["cilium"],
       automerge: false,
     },
+    // --- Version coupling constraints ---
+    // These prevent Renovate from proposing upgrades beyond what the
+    // parent dependency supports. Update the allowedVersions when the
+    // parent is upgraded.
+    {
+      description: "Gateway API pinned to max supported by Cilium 1.18.x",
+      matchPackageNames: ["kubernetes-sigs/gateway-api"],
+      allowedVersions: "<=v1.3.0",
+    },
+    {
+      description: "kubectl pinned to K8s server version ±1 skew policy (K8s 1.32)",
+      matchPackageNames: ["aqua:kubernetes/kubectl"],
+      allowedVersions: "<=1.33",
+    },
+    {
+      description: "Remind to update gateway-api allowedVersions when Cilium upgrades",
+      matchPackageNames: ["cilium"],
+      prBodyNotes: [
+        "⚠️ **Coupled dependency**: After merging, update `allowedVersions` for `kubernetes-sigs/gateway-api` in `renovate.json5` to match the new Cilium version's supported Gateway API. See [Cilium Gateway API docs](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api.html).",
+      ],
+    },
+    {
+      description: "Remind to update kubectl allowedVersions when Talos/K8s upgrades",
+      matchPackageNames: ["aqua:siderolabs/talos"],
+      prBodyNotes: [
+        "⚠️ **Coupled dependency**: After merging, update `allowedVersions` for `aqua:kubernetes/kubectl` in `renovate.json5` to stay within ±1 of the new K8s server version (kubectl skew policy).",
+      ],
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Adds Renovate constraints to prevent incompatible dependency upgrades discovered while reviewing PR #516 (Gateway API v1.3.0 → v1.5.1, which is unsupported by Cilium 1.18.x).

### Hard constraints (`allowedVersions`)

| Dependency | Constraint | Reason |
|---|---|---|
| `kubernetes-sigs/gateway-api` | `<=v1.3.0` | Max supported by Cilium 1.18.x |
| `aqua:kubernetes/kubectl` | `<=1.33` | K8s 1.32 ±1 skew policy |

### Active reminders (`prBodyNotes`)

- **Cilium PRs** → reminder to update gateway-api `allowedVersions`
- **Talos PRs** → reminder to update kubectl `allowedVersions`

Blocked updates will also appear in the Renovate Dependency Dashboard.

### Soft constraints (grouping)

- **Kustomize** grouped with ArgoCD (currently both at 5.8.1)
- **Helm** grouped with ArgoCD (bundled 3.19.4 vs mise 3.20.1)

Closes review of #516.