### PR TITLE
fix(ci): pin Helm to 3.x — ArgoCD bundles Helm 3.19.4

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -62,6 +62,11 @@
       allowedVersions: "<=1.33",
     },
     {
+      description: "Helm pinned to 3.x — ArgoCD bundles Helm 3.19.4, Helm 4 is incompatible",
+      matchPackageNames: ["aqua:helm/helm"],
+      allowedVersions: "<4",
+    },
+    {
       description: "Remind to update gateway-api allowedVersions when Cilium upgrades",
       matchPackageNames: ["cilium"],
       prBodyNotes: [
@@ -73,6 +78,13 @@
       matchPackageNames: ["aqua:siderolabs/talos"],
       prBodyNotes: [
         "⚠️ **Coupled dependency**: After merging, update `allowedVersions` for `aqua:kubernetes/kubectl` in `renovate.json5` to stay within ±1 of the new K8s server version (kubectl skew policy).",
+      ],
+    },
+    {
+      description: "Remind to check Helm/Kustomize bundled versions when ArgoCD upgrades",
+      matchPackageNames: ["aqua:argoproj/argo-cd"],
+      prBodyNotes: [
+        "⚠️ **Coupled dependency**: After merging, verify ArgoCD's bundled Helm and Kustomize versions (`kubectl -n argocd exec deploy/argocd-repo-server -- helm version --short` / `kustomize version`) and update `allowedVersions` for `aqua:helm/helm` in `renovate.json5` if needed.",
       ],
     },
   ],


### PR DESCRIPTION
Helm 4 is a major version with breaking changes. ArgoCD 3.3.6 bundles Helm 3.19.4, so the local/CI Helm must stay on 3.x.

Adds `allowedVersions: "<4"` for `aqua:helm/helm` to prevent Renovate from proposing Helm 4.x upgrades (see PR #510).

Also adds `prBodyNotes` on ArgoCD PRs reminding to check bundled Helm/Kustomize versions after upgrading.

Follow-up to #523.