### PR TITLE
fix(ci): group Gateway API CRDs with Cilium in Renovate

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -57,9 +57,9 @@
       groupName: "cilium",
     },
     {
-      description: "Group Gateway API CRDs (Cilium dependency)",
+      description: "Group Gateway API CRDs with Cilium — CRDs must be updated before or with Cilium",
       matchPackageNames: ["kubernetes-sigs/gateway-api"],
-      groupName: "gateway-api",
+      groupName: "cilium",
     },
     {
       description: "Group Kustomize (mise) with ArgoCD — must match ArgoCD bundled version",

--- a/renovate.json5
+++ b/renovate.json5
@@ -70,7 +70,7 @@
       description: "Remind to update gateway-api allowedVersions when Cilium upgrades",
       matchPackageNames: ["cilium"],
       prBodyNotes: [
-        "⚠️ **Coupled dependency**: After merging, update `allowedVersions` for `kubernetes-sigs/gateway-api` in `renovate.json5` to match the new Cilium version's supported Gateway API. See [Cilium Gateway API docs](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api.html).",
+        "⚠️ **Coupled dependency**: Gateway API CRDs are grouped with this PR. Before merging, update `allowedVersions` for `kubernetes-sigs/gateway-api` in `renovate.json5` to match the new Cilium version's supported Gateway API, then let Renovate rebase to include the CRD update. See [Cilium Gateway API docs](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api.html).",
       ],
     },
     {


### PR DESCRIPTION
Gateway API CRDs are a prerequisite for Cilium's Gateway API controller — they must be updated **before or alongside** Cilium, never after.

### Changes

- **`.renovate/groups.json5`**: Moved `kubernetes-sigs/gateway-api` from its own `gateway-api` group into the `cilium` group. Cilium PRs will now include Gateway API CRD changes.

- **`renovate.json5`**: Updated Cilium `prBodyNotes` to reflect the new workflow: bump `allowedVersions` on main first, let Renovate rebase, then the Cilium PR includes both.

### Upgrade workflow

1. Cilium upgrade PR arrives (includes Cilium + CLI, but gateway-api is blocked by `allowedVersions`)
2. Update `allowedVersions` for `kubernetes-sigs/gateway-api` on `main` to match the new Cilium's supported version
3. Renovate rebases the Cilium PR → now includes the gateway-api CRD bump
4. Merge — CRDs and Cilium land together

Follow-up to #523 and #524.