### PR TITLE
fix(ci): group kubectl with Talos, update prBodyNotes to before-merge

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -72,6 +72,16 @@
       groupName: "argocd",
     },
     {
+      description: "Group kubectl (mise) with Talos — kubectl version tied to K8s version from Talos",
+      matchPackageNames: ["aqua:kubernetes/kubectl"],
+      groupName: "talos",
+    },
+    {
+      description: "Group Talos CLI (mise) into talos group",
+      matchPackageNames: ["aqua:siderolabs/talos"],
+      groupName: "talos",
+    },
+    {
       description: "Group SOPS CLI (mise) with KSOPS",
       matchPackageNames: ["aqua:getsops/sops", "viaduct-ai/kustomize-sops"],
       groupName: "sops",

--- a/renovate.json5
+++ b/renovate.json5
@@ -77,14 +77,14 @@
       description: "Remind to update kubectl allowedVersions when Talos/K8s upgrades",
       matchPackageNames: ["aqua:siderolabs/talos"],
       prBodyNotes: [
-        "⚠️ **Coupled dependency**: After merging, update `allowedVersions` for `aqua:kubernetes/kubectl` in `renovate.json5` to stay within ±1 of the new K8s server version (kubectl skew policy).",
+        "⚠️ **Coupled dependency**: kubectl is grouped with this PR. Before merging, update `allowedVersions` for `aqua:kubernetes/kubectl` in `renovate.json5` to stay within ±1 of the new K8s server version (kubectl skew policy), then let Renovate rebase to include the kubectl update.",
       ],
     },
     {
       description: "Remind to check Helm/Kustomize bundled versions when ArgoCD upgrades",
       matchPackageNames: ["aqua:argoproj/argo-cd"],
       prBodyNotes: [
-        "⚠️ **Coupled dependency**: After merging, verify ArgoCD's bundled Helm and Kustomize versions (`kubectl -n argocd exec deploy/argocd-repo-server -- helm version --short` / `kustomize version`) and update `allowedVersions` for `aqua:helm/helm` in `renovate.json5` if needed.",
+        "⚠️ **Coupled dependency**: Kustomize and Helm are grouped with this PR. Before merging, verify ArgoCD's bundled Helm and Kustomize versions (`kubectl -n argocd exec deploy/argocd-repo-server -- helm version --short` / `kustomize version`) and update `allowedVersions` for `aqua:helm/helm` in `renovate.json5` if needed, then let Renovate rebase.",
       ],
     },
   ],


### PR DESCRIPTION
Same pattern as Cilium + Gateway API (#525): coupled dependencies must be updated before or alongside their parent, not after.

### Changes

**`.renovate/groups.json5`:**
- Group `aqua:kubernetes/kubectl` into `talos` group (K8s version from Talos determines kubectl skew)
- Group `aqua:siderolabs/talos` into `talos` group

**`renovate.json5`:**
- Talos `prBodyNotes`: updated to 'before merging, update `allowedVersions` for kubectl, then let Renovate rebase'
- ArgoCD `prBodyNotes`: updated to 'before merging, verify bundled Helm/Kustomize versions, then let Renovate rebase'

### Consistent upgrade workflow (all couplings)

1. Parent upgrade PR arrives (Cilium/Talos/ArgoCD)
2. Update `allowedVersions` for the coupled dep on `main`
3. Renovate rebases → PR now includes both parent + coupled dep
4. Merge together

Follow-up to #523, #524, #525.