### PR TITLE
fix(ci): use matchDepNames for mise packages in Renovate rules

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -8,7 +8,7 @@
     },
     {
       description: "Group Velero CLI (mise) with Velero deployment",
-      matchPackageNames: ["aqua:vmware-tanzu/velero"],
+      matchDepNames: ["aqua:vmware-tanzu/velero"],
       groupName: "velero",
     },
     {
@@ -38,7 +38,7 @@
     },
     {
       description: "Group ArgoCD CLI (mise) with ArgoCD deployment",
-      matchPackageNames: ["aqua:argoproj/argo-cd"],
+      matchDepNames: ["aqua:argoproj/argo-cd"],
       groupName: "argocd",
     },
     {
@@ -53,7 +53,7 @@
     },
     {
       description: "Group Cilium CLI (mise) with Cilium deployment",
-      matchPackageNames: ["aqua:cilium/cilium-cli"],
+      matchDepNames: ["aqua:cilium/cilium-cli"],
       groupName: "cilium",
     },
     {
@@ -63,27 +63,32 @@
     },
     {
       description: "Group Kustomize (mise) with ArgoCD — must match ArgoCD bundled version",
-      matchPackageNames: ["aqua:kubernetes-sigs/kustomize"],
+      matchDepNames: ["aqua:kubernetes-sigs/kustomize"],
       groupName: "argocd",
     },
     {
       description: "Group Helm (mise) with ArgoCD — should stay close to ArgoCD bundled version",
-      matchPackageNames: ["aqua:helm/helm"],
+      matchDepNames: ["aqua:helm/helm"],
       groupName: "argocd",
     },
     {
       description: "Group kubectl (mise) with Talos — kubectl version tied to K8s version from Talos",
-      matchPackageNames: ["aqua:kubernetes/kubectl"],
+      matchDepNames: ["aqua:kubernetes/kubectl"],
       groupName: "talos",
     },
     {
       description: "Group Talos CLI (mise) into talos group",
-      matchPackageNames: ["aqua:siderolabs/talos"],
+      matchDepNames: ["aqua:siderolabs/talos"],
       groupName: "talos",
     },
     {
       description: "Group SOPS CLI (mise) with KSOPS",
-      matchPackageNames: ["aqua:getsops/sops", "viaduct-ai/kustomize-sops"],
+      matchDepNames: ["aqua:getsops/sops"],
+      groupName: "sops",
+    },
+    {
+      description: "Group KSOPS with SOPS",
+      matchPackageNames: ["viaduct-ai/kustomize-sops"],
       groupName: "sops",
     },
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -58,12 +58,12 @@
     },
     {
       description: "kubectl pinned to K8s server version ±1 skew policy (K8s 1.32)",
-      matchPackageNames: ["aqua:kubernetes/kubectl"],
+      matchDepNames: ["aqua:kubernetes/kubectl"],
       allowedVersions: "<=1.33",
     },
     {
       description: "Helm pinned to 3.x — ArgoCD bundles Helm 3.19.4, Helm 4 is incompatible",
-      matchPackageNames: ["aqua:helm/helm"],
+      matchDepNames: ["aqua:helm/helm"],
       allowedVersions: "<4",
     },
     {
@@ -75,14 +75,14 @@
     },
     {
       description: "Remind to update kubectl allowedVersions when Talos/K8s upgrades",
-      matchPackageNames: ["aqua:siderolabs/talos"],
+      matchDepNames: ["aqua:siderolabs/talos"],
       prBodyNotes: [
         "⚠️ **Coupled dependency**: kubectl is grouped with this PR. Before merging, update `allowedVersions` for `aqua:kubernetes/kubectl` in `renovate.json5` to stay within ±1 of the new K8s server version (kubectl skew policy), then let Renovate rebase to include the kubectl update.",
       ],
     },
     {
       description: "Remind to check Helm/Kustomize bundled versions when ArgoCD upgrades",
-      matchPackageNames: ["aqua:argoproj/argo-cd"],
+      matchDepNames: ["aqua:argoproj/argo-cd"],
       prBodyNotes: [
         "⚠️ **Coupled dependency**: Kustomize and Helm are grouped with this PR. Before merging, verify ArgoCD's bundled Helm and Kustomize versions (`kubectl -n argocd exec deploy/argocd-repo-server -- helm version --short` / `kustomize version`) and update `allowedVersions` for `aqua:helm/helm` in `renovate.json5` if needed, then let Renovate rebase.",
       ],


### PR DESCRIPTION
### Root cause

For mise-managed packages, Renovate sets:
- `depName`: `aqua:helm/helm` (with prefix)
- `packageName`: `helm/helm` (without prefix)

`matchPackageNames` matches against `packageName`, so rules like `matchPackageNames: ["aqua:helm/helm"]` silently failed to match `packageName: "helm/helm"`.

This is why `allowedVersions: "<4"` for Helm wasn't being applied — the rule never matched the package.

### Fix

Changed all mise package rules from `matchPackageNames` to `matchDepNames`, which correctly matches the prefixed `depName`.

Affects both `renovate.json5` (allowedVersions + prBodyNotes) and `.renovate/groups.json5` (group rules for CLI tools).

### Pre-existing bug

The group rules for Velero CLI, ArgoCD CLI, Cilium CLI, and SOPS CLI (pre-existing before #523) also used `matchPackageNames` with `aqua:` prefix — these were silently not grouping either. Fixed in this PR.