### PR TITLE
fix(ci): add Talos to critical-infra labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,3 +22,4 @@
       - any-glob-to-any-file:
           - "kubernetes/infra/cilium/**"
           - "kubernetes/infra/gateway-api/**"
+          - "hack/talos/**"


### PR DESCRIPTION
Adds `hack/talos/**` to the `critical-infra` label rule so Talos PRs get flagged for careful review alongside Cilium and Gateway API.