### PR TITLE
fix: Renovate custom managers and grouping for Talos/K8s

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -60,11 +60,21 @@
     },
     {
       customType: "regex",
-      description: "Track Talos and Kubernetes versions in talconfig.yaml",
+      description: "Track Talos version in talconfig.yaml",
       managerFilePatterns: ["/talos/talconfig\\.yaml$/"],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\n\\w+:\\s*(?<currentValue>v\\S+)",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>ghcr\\.io/siderolabs/installer)\\ntalosVersion:\\s*(?<currentValue>v\\S+)",
       ],
+      autoReplaceStringTemplate: "# renovate: datasource={{{datasource}}} depName={{{depName}}}\ntalosVersion: {{{newValue}}}",
+    },
+    {
+      customType: "regex",
+      description: "Track Kubernetes version in talconfig.yaml",
+      managerFilePatterns: ["/talos/talconfig\\.yaml$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>ghcr\\.io/siderolabs/kubelet)\\nkubernetesVersion:\\s*(?<currentValue>v\\S+)",
+      ],
+      autoReplaceStringTemplate: "# renovate: datasource={{{datasource}}} depName={{{depName}}}\nkubernetesVersion: {{{newValue}}}",
     },
     {
       customType: "regex",
@@ -73,6 +83,7 @@
       matchStrings: [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\n\\s+version:\\s*(?<currentValue>v\\S+)",
       ],
+      autoReplaceStringTemplate: "# renovate: datasource={{{datasource}}} depName={{{depName}}}\n    version: {{{newValue}}}",
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -93,8 +93,14 @@
       ],
     },
     {
-      description: "Separate Talos minor/patch PRs for safe sequential upgrade paths",
+      description: "Separate Talos installer minor/patch PRs for safe sequential upgrade paths",
       matchPackageNames: ["ghcr.io/siderolabs/installer"],
+      separateMajorMinor: true,
+      separateMinorPatch: true,
+    },
+    {
+      description: "Separate talosctl minor/patch PRs to match installer branch naming",
+      matchDepNames: ["aqua:siderolabs/talos"],
       separateMajorMinor: true,
       separateMinorPatch: true,
     },


### PR DESCRIPTION
## Problem

Two issues with Renovate after #535:

### 1. Update failure on Tuppr CRDs and talconfig.yaml
The `docker` datasource returns a digest (`sha256:...`) with each version. The regex custom managers had no `autoReplaceStringTemplate`, so Renovate could not construct the replacement string — it matched the version but failed to update the file content.

**Fix**: Added explicit `autoReplaceStringTemplate` to all three custom managers (excluding digest). Split the talconfig manager into two separate ones since `talosVersion` and `kubernetesVersion` have different field names.

### 2. Group split by `separateMinorPatch`
`separateMinorPatch` was only applied to `ghcr.io/siderolabs/installer`, causing it to get branch `renovate/patch-talos`. But `aqua:siderolabs/talos` (talosctl) did not have this flag and got branch `renovate/talos`. Same group, different branches → split PRs.

**Fix**: Added matching `separateMinorPatch` rule for `aqua:siderolabs/talos` so both deps get the same branch naming.

## Validation
- ✅ `just lint renovate` passes