### PR TITLE
fix: disable digest pinning for Talos/K8s version tracking

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -108,6 +108,7 @@
       description: "Never automerge Talos or Kubernetes upgrades — require manual review",
       matchPackageNames: ["ghcr.io/siderolabs/installer", "ghcr.io/siderolabs/kubelet"],
       automerge: false,
+      pinDigests: false,
       labels: ["manual-review"],
     },
     {


### PR DESCRIPTION
## Problem

Renovate still fails with `Error updating branch: update failure` on the `renovate/talos` branch. The `autoReplaceStringTemplate` from #537 tells Renovate how to format the replacement, but `config:best-practices` enables `pinDigests: true` globally. Renovate tries to write a digest into the regex-managed files but fails because the template does not include `{{{newDigest}}}` — these are version references, not container image references.

## Fix

Added `pinDigests: false` to the package rule matching `ghcr.io/siderolabs/installer` and `ghcr.io/siderolabs/kubelet`. This prevents Renovate from attempting digest updates on talconfig.yaml and Tuppr CRD files.

## Validation
- ✅ `just lint renovate` passes