### PR TITLE
fix: iSCSI health-check — increase PVC size, restrict to workers

### DIFF
--- a/kubernetes/infra/tuppr/upgrades/health-check.yaml
+++ b/kubernetes/infra/tuppr/upgrades/health-check.yaml
@@ -12,10 +12,7 @@ spec:
       labels:
         app: iscsi-health-check
     spec:
-      tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule
+      # No CP toleration — iSCSI CSI driver only runs on worker nodes
       containers:
         - name: probe
           image: busybox:latest
@@ -50,4 +47,4 @@ spec:
                 storageClassName: zfs-generic-iscsi-csi-xfs
                 resources:
                   requests:
-                    storage: 128Mi
+                    storage: 512Mi


### PR DESCRIPTION
## Problem

All 6 iSCSI health-check pods stuck in `ContainerCreating` for 100+ minutes, triggering Prometheus alerts.

### Root causes:

1. **XFS minimum filesystem size**: `mkfs.xfs` requires at least ~300MB. Our 128Mi PVC fails with:
   ```
   Filesystem must be larger than 300MB.
   ```

2. **CSI driver not on CP nodes**: The DaemonSet tolerated control-plane nodes, but `org.democratic-csi.iscsi` is only registered on workers:
   ```
   talos-01      org.democratic-csi.iscsi,org.democratic-csi.nfs
   talos-02      org.democratic-csi.nfs,org.democratic-csi.iscsi
   talos-03      org.democratic-csi.nfs,org.democratic-csi.iscsi
   talos-cp-01   <none>
   talos-cp-02   <none>
   talos-cp-03   <none>
   ```

## Fix

- Increased PVC size from 128Mi → 512Mi
- Removed control-plane toleration (DaemonSet now only runs on 3 worker nodes)