### PR TITLE
fix: remove invalid Pod CEL health check from TalosUpgrade

### DIFF
--- a/kubernetes/infra/tuppr/upgrades/talos.yaml
+++ b/kubernetes/infra/tuppr/upgrades/talos.yaml
@@ -20,7 +20,7 @@ spec:
     # --- CNI: Cilium agent DaemonSet fully rolled out and available ---
     - apiVersion: apps/v1
       kind: DaemonSet
-      name: cilium-agent
+      name: cilium
       namespace: kube-system
       expr: |-
         status.desiredNumberScheduled > 0 &&
@@ -42,23 +42,6 @@ spec:
         status.updatedReplicas == status.replicas
       timeout: 5m
 
-    # --- CNI: Cilium agent pods not crash-looping ---
-    # Scoped to agent pods only (k8s-app=cilium), NOT the operator.
-    # Agents may restart once if the API server is briefly unreachable
-    # during a CP node upgrade. Threshold of 2 tolerates one such
-    # restart while catching true crash-loops (10+ restarts in minutes).
-    - apiVersion: v1
-      kind: Pod
-      namespace: kube-system
-      expr: |-
-        !("k8s-app" in metadata.labels) ||
-        metadata.labels["k8s-app"] != "cilium" ||
-        (
-          status.containerStatuses.all(cs, cs.restartCount < 2 && cs.ready == true) &&
-          status.phase == "Running"
-        )
-      timeout: 10m
-
     # --- CNI: Envoy proxy healthy (used for Gateway API + Ingress) ---
     - apiVersion: apps/v1
       kind: DaemonSet
@@ -70,9 +53,21 @@ spec:
         status.numberUnavailable == 0
       timeout: 5m
 
-    # --- CSI: democratic-csi node DaemonSets healthy (per-node driver check) ---
+    # --- CSI: democratic-csi iSCSI node driver healthy ---
     - apiVersion: apps/v1
       kind: DaemonSet
+      name: democratic-csi-iscsi-node
+      namespace: infra
+      expr: |-
+        status.desiredNumberScheduled > 0 &&
+        status.numberReady == status.desiredNumberScheduled &&
+        status.numberUnavailable == 0
+      timeout: 10m
+
+    # --- CSI: democratic-csi NFS node driver healthy ---
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: democratic-csi-nfs-node
       namespace: infra
       expr: |-
         status.desiredNumberScheduled > 0 &&


### PR DESCRIPTION
## Problem

TalosUpgrade is stuck in `HealthChecking` phase — the Pod-level CEL expression uses `metadata.labels` but Tuppr's CEL environment only exposes the `status` field:

```
health check 3: invalid CEL expression: undeclared reference to 'metadata'
```

This has been blocking Tuppr since deployment and is now blocking the v1.12.6 upgrade.

## Fix

Removed the Pod-level restartCount health check entirely. The Cilium **DaemonSet** check (`numberUnavailable == 0`, `numberReady == desiredNumberScheduled`) already catches crash-loops — if a cilium pod is crash-looping, the DaemonSet reports `numberUnavailable > 0`.

Remaining health checks (6):
1. Node Ready
2. Cilium agent DaemonSet
3. Cilium operator Deployment
4. Cilium Envoy DaemonSet
5. CSI DaemonSets (infra namespace)
6. iSCSI data-path DaemonSet (ephemeral volumes)