### PR TITLE
fix: handle nil numberUnavailable in DaemonSet CEL health checks

### DIFF
--- a/kubernetes/infra/tuppr/upgrades/talos.yaml
+++ b/kubernetes/infra/tuppr/upgrades/talos.yaml
@@ -25,7 +25,7 @@ spec:
       expr: |-
         status.desiredNumberScheduled > 0 &&
         status.numberReady == status.desiredNumberScheduled &&
-        status.numberUnavailable == 0 &&
+        (!has(status.numberUnavailable) || status.numberUnavailable == 0) &&
         status.updatedNumberScheduled == status.desiredNumberScheduled
       timeout: 10m
 
@@ -50,7 +50,7 @@ spec:
       expr: |-
         status.desiredNumberScheduled > 0 &&
         status.numberReady == status.desiredNumberScheduled &&
-        status.numberUnavailable == 0
+        (!has(status.numberUnavailable) || status.numberUnavailable == 0)
       timeout: 5m
 
     # --- CSI: democratic-csi iSCSI node driver healthy ---
@@ -61,7 +61,7 @@ spec:
       expr: |-
         status.desiredNumberScheduled > 0 &&
         status.numberReady == status.desiredNumberScheduled &&
-        status.numberUnavailable == 0
+        (!has(status.numberUnavailable) || status.numberUnavailable == 0)
       timeout: 10m
 
     # --- CSI: democratic-csi NFS node driver healthy ---
@@ -72,7 +72,7 @@ spec:
       expr: |-
         status.desiredNumberScheduled > 0 &&
         status.numberReady == status.desiredNumberScheduled &&
-        status.numberUnavailable == 0
+        (!has(status.numberUnavailable) || status.numberUnavailable == 0)
       timeout: 10m
 
     # --- CSI: per-node iSCSI data-path probe (see health-check.yaml) ---
@@ -83,5 +83,5 @@ spec:
       expr: |-
         status.desiredNumberScheduled > 0 &&
         status.numberReady == status.desiredNumberScheduled &&
-        status.numberUnavailable == 0
+        (!has(status.numberUnavailable) || status.numberUnavailable == 0)
       timeout: 10m


### PR DESCRIPTION
## Problem

Tuppr health checks have 5 evaluation errors every 10 seconds. All DaemonSets are healthy, but `status.numberUnavailable == 0` fails in CEL because Kubernetes **omits** `numberUnavailable` from the status when the value is zero — the field simply does not exist.

## Fix

Replaced `status.numberUnavailable == 0` with `(!has(status.numberUnavailable) || status.numberUnavailable == 0)` in all 5 DaemonSet health checks. The `has()` CEL function returns false for absent fields.

## Validation
All DaemonSets confirmed healthy: cilium (6/6), cilium-envoy (6/6), democratic-csi-iscsi-node (3/3), democratic-csi-nfs-node (3/3), iscsi-health-check (3/3).