### PR TITLE
fix: step K8s upgrade to v1.33.10 (sequential minor path)

### DIFF
--- a/kubernetes/infra/tuppr/upgrades/kubernetes.yaml
+++ b/kubernetes/infra/tuppr/upgrades/kubernetes.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.35.3
+    version: v1.33.10
   healthChecks:
     # --- Node readiness ---
     - apiVersion: v1

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -3,7 +3,7 @@ clusterName: talos-proxmox-cluster
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.12.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.3
+kubernetesVersion: v1.33.10
 endpoint: https://10.3.0.30:6443
 
 clusterPodNets:


### PR DESCRIPTION
## Problem

Talos enforces sequential K8s minor upgrades. The merged PR #553 set v1.35.3 which Tuppr rejected:
```
unsupported upgrade path 1.32->1.35 (from "1.32.13" to "1.35.3")
```
