### PR TITLE
fix: step K8s upgrade to v1.34.6

### DIFF
--- a/kubernetes/infra/tuppr/upgrades/kubernetes.yaml
+++ b/kubernetes/infra/tuppr/upgrades/kubernetes.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.33.10
+    version: v1.34.6
   healthChecks:
     # --- Node readiness ---
     - apiVersion: v1

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -3,7 +3,7 @@ clusterName: talos-proxmox-cluster
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.12.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.33.10
+kubernetesVersion: v1.34.6
 endpoint: https://10.3.0.30:6443
 
 clusterPodNets:


### PR DESCRIPTION
Sequential K8s minor upgrade: v1.33.10 → v1.34.6.

Merge after [#555](https://github.com/mpeterson/homelab/pull/555) (v1.32.13 → v1.33.10) Tuppr upgrade completes. After this one completes, Renovate will propose v1.35.x.