### PR TITLE
feat(ansible): add corosync-qnetd role for NAS quorum

### DIFF
--- a/ansible/playbooks/corosync_qnetd/setup.yaml
+++ b/ansible/playbooks/corosync_qnetd/setup.yaml
@@ -1,0 +1,6 @@
+---
+- hosts: qnetd
+  name: Configure corosync-qnetd quorum device
+
+  roles:
+    - corosync_qnetd

--- a/ansible/playbooks/setup.yaml
+++ b/ansible/playbooks/setup.yaml
@@ -4,3 +4,6 @@
 
 - name: Run bind9 setup playbook
   ansible.builtin.import_playbook: bind9/setup.yaml
+
+- name: Run corosync-qnetd setup playbook
+  ansible.builtin.import_playbook: corosync_qnetd/setup.yaml

--- a/ansible/roles/corosync_qnetd/defaults/main.yaml
+++ b/ansible/roles/corosync_qnetd/defaults/main.yaml
@@ -1,0 +1,14 @@
+---
+# corosync-qnetd defaults
+
+# Network port for the qnetd daemon
+corosync_qnetd_port: 5403
+
+# NSS certificate database path
+corosync_qnetd_nss_db: /etc/corosync/qnetd/nssdb
+
+# Quorum algorithm: ffsplit (fifty-fifty split) is correct for 2-node clusters
+corosync_qnetd_algorithm: ffsplit
+
+# Firewall service name for high-availability (includes port 5403)
+corosync_qnetd_firewall_service: high-availability

--- a/ansible/roles/corosync_qnetd/handlers/main.yaml
+++ b/ansible/roles/corosync_qnetd/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: Restart corosync-qnetd
+  ansible.builtin.systemd:
+    name: corosync-qnetd
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/corosync_qnetd/tasks/main.yaml
+++ b/ansible/roles/corosync_qnetd/tasks/main.yaml
@@ -1,0 +1,29 @@
+---
+- name: Install corosync-qnetd package
+  ansible.builtin.dnf:
+    name: corosync-qnetd
+    state: present
+
+- name: Open firewall for high-availability services (port {{ corosync_qnetd_port }})
+  ansible.posix.firewalld:
+    service: "{{ corosync_qnetd_firewall_service }}"
+    permanent: true
+    immediate: true
+    state: enabled
+
+- name: Check if NSS certificate database exists
+  ansible.builtin.stat:
+    path: "{{ corosync_qnetd_nss_db }}/cert9.db"
+  register: nss_db
+
+- name: Initialize NSS certificate database for qnetd
+  ansible.builtin.command: corosync-qnetd-certutil -i
+  when: not nss_db.stat.exists
+  changed_when: true
+  notify: Restart corosync-qnetd
+
+- name: Enable and start corosync-qnetd service
+  ansible.builtin.systemd:
+    name: corosync-qnetd
+    enabled: true
+    state: started

--- a/ansible/sample_inventory/qnetd.yaml
+++ b/ansible/sample_inventory/qnetd.yaml
@@ -1,0 +1,6 @@
+---
+qnetd:
+  hosts:
+    qnetd-01.local.example.com:
+      ansible_user: mpeterson
+      ansible_become: true


### PR DESCRIPTION
## What

Adds a lightweight Ansible role and playbook to provision the **corosync-qnetd** quorum device on a dedicated VM (`qnetd-01`, IP `10.3.25.13`).

This provides a third vote for the 2-node NAS cluster (`zfs-cluster`), enabling proper majority quorum (2 of 3) instead of relying on `two_node: 1` mode with `no-quorum-policy=ignore`.

## Components

| File | Purpose |
|---|---|
| `ansible/roles/corosync_qnetd/defaults/main.yaml` | Role variables (port 5403, cert paths, ffsplit algorithm) |
| `ansible/roles/corosync_qnetd/tasks/main.yaml` | Install corosync-qnetd, firewall rules, NSS cert init, enable service |
| `ansible/roles/corosync_qnetd/handlers/main.yaml` | Restart handler |
| `ansible/playbooks/corosync_qnetd/setup.yaml` | Playbook targeting the `qnetd` host group |
| `ansible/sample_inventory/qnetd.yaml` | Sample inventory for the qnetd host |
| `ansible/playbooks/setup.yaml` | Updated to import the new qnetd playbook |

## Deploy-time steps (not in this PR)

These must be done at the maintenance window when deploying:

1. **Create VM** — Manually provision AlmaLinux 9.5 minimal VM in Proxmox (1 vCPU, 512 MB RAM, 8 GB disk, NIC on 10.3.25.0/24 storage VLAN)
2. **Add inventory** — Create `ansible/inventories/qnetd.yaml` with `qnetd-01.lan.peterson.com.ar` (10.3.25.13)
3. **DNS zone update** — Add `qnetd-01 IN A 10.3.25.13` to `ansible/inventories/files/bind9/dynamic/lan.peterson.com.ar.zone` and bump SOA serial (2026041104 → 2026041901), then run bind9 playbook with `force_dynamic_zone_update=true`
4. **Run playbook** — `ansible-playbook playbooks/corosync_qnetd/setup.yaml -i inventories/qnetd.yaml`
5. **Configure qdevice on NAS nodes** — Install `corosync-qdevice` on nas-01/nas-02, run `pcs qdevice setup model net --qnetd-hostname qnetd-01` and `pcs quorum device add model net host=qnetd-01 algorithm=ffsplit`
6. **Switch quorum policy** — `pcs property set no-quorum-policy=stop`

## Context

Addresses the quorum gap identified after the STONITH incident (#656) where a switch auto-update caused corosync quorum loss. With qnetd providing a third vote, single-node failures result in proper quorum behavior instead of relying on the unsafe `no-quorum-policy=ignore` setting.