### PR TITLE
fix(recyclarr): migrate Sonarr CFs from Miscellaneous to Unwanted Formats group

### DIFF
--- a/kubernetes/apps/recyclarr/config/recyclarr.yml
+++ b/kubernetes/apps/recyclarr/config/recyclarr.yml
@@ -67,9 +67,8 @@ sonarr:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
         - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             - 06d66ab109d4d2eddb2794d21526d140  # Retags


### PR DESCRIPTION
## Problem

Recyclarr CronJob has been failing since the 8.5.1→8.6.0 update (PR #712) with:
```
[ERR] tv: CF group 'f4a0410a1df109a66d6e47dcadcce014': Invalid CF trash_id in select: 32b367365729d530ca1c124a0b180c64
```

Last two scheduled jobs failed, previous two succeeded.

## Root Cause

TRaSH Guides reorganized their Sonarr CF groups. Five custom formats (Bad Dual Groups, No-RlsGroup, Obfuscated, Retags, Scene) were moved from `[Optional] Miscellaneous` to a new `[Unwanted] Unwanted Formats` group. The config's `select` entries referenced CFs that no longer exist in the Miscellaneous group.

## Fix

Replace the `[Optional] Miscellaneous` group reference with the new `[Unwanted] Unwanted Formats` group (`59c3af66`). Bad Dual Groups is now `default: true` in the new group (auto-included), so only the remaining 4 CFs need explicit `select`.