### PR TITLE
refactor(recyclarr): switch to includes pattern for resilient CF management

### DIFF
--- a/kubernetes/apps/recyclarr/config/recyclarr.yml
+++ b/kubernetes/apps/recyclarr/config/recyclarr.yml
@@ -6,41 +6,52 @@ radarr:
     api_key: !secret radarr_apikey
     delete_old_custom_formats: true
 
+    include:
+      - template: radarr-quality-definition-movie
+      - template: radarr-quality-profile-uhd-bluray-web
+      - template: radarr-quality-profile-hd-bluray-web
+      - template: radarr-custom-formats-uhd-bluray-web
+      - template: radarr-custom-formats-hd-bluray-web
+
     media_naming:
       folder: plex-tmdb
       movie:
         rename: true
         standard: plex-tmdb
 
-    quality_definition:
-      type: movie
+    custom_formats:
+      # HDR10+ Boost - prefer HDR10+ releases
+      - trash_ids:
+          - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
+        assign_scores_to:
+          - name: UHD Bluray + WEB
 
-    quality_profiles:
-      - trash_id: 64fb5f9858489bdac2af690e27c8f42f  # UHD Bluray + WEB
-        reset_unmatched_scores:
-          enabled: true
-      - trash_id: d1d67249d3890e49bc12e275d989a7e9  # HD Bluray + WEB
-        reset_unmatched_scores:
-          enabled: true
+      # Movie Versions
+      - trash_ids:
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        assign_scores_to:
+          - name: UHD Bluray + WEB
+          - name: HD Bluray + WEB
 
-    custom_format_groups:
-      add:
-        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
-        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
-        - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-          select:
-            - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-          select:
-            - 9c38ebb7384dada637be8899efa68e6f  # SDR
-            # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+      # Optional SDR
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
+        assign_scores_to:
+          - name: UHD Bluray + WEB
 
 sonarr:
   tv:
     base_url: !secret sonarr_url
     api_key: !secret sonarr_apikey
     delete_old_custom_formats: true
+
+    include:
+      - template: sonarr-quality-definition-series
+      - template: sonarr-v4-quality-profile-web-2160p
+      - template: sonarr-v4-quality-profile-web-1080p
+      - template: sonarr-v4-custom-formats-web-2160p
+      - template: sonarr-v4-custom-formats-web-1080p
 
     media_naming:
       series: plex-tvdb
@@ -51,30 +62,27 @@ sonarr:
         daily: default
         anime: default
 
-    quality_definition:
-      type: series
+    custom_formats:
+      # HDR10+ Boost - prefer HDR10+ releases
+      - trash_ids:
+          - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
+        assign_scores_to:
+          - name: WEB-2160p
 
-    quality_profiles:
-      - trash_id: d1498e7d189fbe6c7110ceaabb7473e6  # WEB-2160p
-        reset_unmatched_scores:
-          enabled: true
-      - trash_id: 72dae194fc92bf828f32cde7744e51a1  # WEB-1080p
-        reset_unmatched_scores:
-          enabled: true
+      # Optional
+      - trash_ids:
+          - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
+          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
+          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
+          - 06d66ab109d4d2eddb2794d21526d140 # Retags
+          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
+        assign_scores_to:
+          - name: WEB-2160p
+          - name: WEB-1080p
 
-    custom_format_groups:
-      add:
-        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
-        - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-          select:
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
-            - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
-            - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-        - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-          select:
-            - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-            # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+      # Optional SDR
+      - trash_ids:
+          - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
+          # - 83304f261cf516bb208c18c54c0adf97 # SDR (no WEBDL)
+        assign_scores_to:
+          - name: WEB-2160p


### PR DESCRIPTION
## Summary

Replace the fragile `custom_format_groups` + `select` pattern with recyclarr's upstream-maintained **include templates**. This eliminates the coupling to TRaSH Guides' CF group organization, which caused the CronJob breakage fixed in #719.

## What changed

- **Added `include:` directives** for official recyclarr config templates:
  - Quality definitions (`radarr-quality-definition-movie`, `sonarr-quality-definition-series`)
  - Quality profiles (`radarr-quality-profile-{uhd,hd}-bluray-web`, `sonarr-v4-quality-profile-web-{2160p,1080p}`)
  - Custom formats (`radarr-custom-formats-{uhd,hd}-bluray-web`, `sonarr-v4-custom-formats-web-{2160p,1080p}`)

- **Removed all `custom_format_groups`** (Golden Rule UHD/HD, HDR Formats, Optional groups)

- **Added direct `custom_formats:`** entries for optional CFs not covered by includes:
  - HDR10+ Boost (UHD/2160p profiles)
  - IMAX Enhanced (both radarr profiles)
  - Bad Dual Groups, No-RlsGroup, Obfuscated, Retags, Scene (sonarr, both profiles)
  - SDR blocking (UHD/2160p profiles)

- **Removed explicit `quality_profiles:`** with `trash_id` references and `quality_definition:` sections — both are now provided by includes

## Why

The `custom_format_groups` pattern couples config to TRaSH Guides' internal group organization. When TRaSH reorganizes groups (moving CFs between groups, renaming groups), the `select` references break. This happened recently and was fixed in #719.

The includes pattern uses direct CF `trash_ids` maintained by the recyclarr project. When TRaSH reorganizes, the recyclarr maintainers update the templates — our config doesn't need to change.

## Preserved behavior

- Same quality profiles (UHD Bluray + WEB, HD Bluray + WEB, WEB-2160p, WEB-1080p)
- Same custom formats coverage
- Same media naming settings
- Same `delete_old_custom_formats: true` behavior
- Same optional CF selections (SDR, IMAX Enhanced, HDR10+ Boost, etc.)