### PR TITLE
fix(velero): replace snapshotMoveData with fs-level backup for weekly offsite

### DIFF
--- a/kubernetes/infra/democratic-csi/app-iscsi.sops.yaml
+++ b/kubernetes/infra/democratic-csi/app-iscsi.sops.yaml
@@ -61,10 +61,10 @@ spec:
                         fsType: ENC[AES256_GCM,data:Hrep,iv:Z1m93qaf9R1s/1f+Icup5EmHo2P6a9SeSVA+zl9Z+v0=,tag:lR8/vfZ5KvRiwntderz46g==,type:str]
                         #ENC[AES256_GCM,data:jMGz68ynBC0qk293c/SWCJxW2Hs5hPsJVSbswleDHhHMznjLlCspnoyYmhSdfCarQa7NKHmf,iv:18R7Ow2Sy79IjqPeQGmLZGfoiv3t4dICd6CPo1zXTtU=,tag:exZJpVDbi5sW63752upMQg==,type:comment]
                         #ENC[AES256_GCM,data:FSjMmBHz9BP/vE9oPrqwH7Hm70+MqGu2DsrtRyuVWiLlMyOKtuPkdQ==,iv:nVd7PX1p5tGtK0iyFGqrZjORan26FSpnYXcAiYoMdOE=,tag:lZlIF12ST6JVhIqtWRkvCg==,type:comment]
-                        #ENC[AES256_GCM,data:pNuhFuAdGgCcWtNmgqmGqLrY5swPuz/1M56hKKicd4O+wNP0rmk=,iv:mnoHwQPlLfR023dZB6zwBwQ+4drwIGS6Ck37Q7vDYKw=,tag:S+3wVqc5kTheRY42zgikDw==,type:comment]
+                        detachedVolumesFromSnapshots: ENC[AES256_GCM,data:xdrceg==,iv:01ywGKeSyVU2Vcsgs3mvJLLBR1OfO1UEayuiJYPukdQ=,tag:z7yZh1+aWBXUxoYvFDmDzA==,type:str]
                         #ENC[AES256_GCM,data:BLprwka98//VtoeMrMlO3J0ctT0lFcx1uskhM9d486oIttDL3TOE1/JC3IuTqS/Y94O+zg==,iv:ktD0ndjbtp20Gik2Nv6tb5Cx08fiRolwzK9Lc5TLoSA=,tag:S/YqAcfGJVpweAVSPkuAkA==,type:comment]
                         #ENC[AES256_GCM,data:FSjMmBHz9BP/vE9oPrqwH7Hm70+MqGu2DsrtRyuVWiLlMyOKtuPkdQ==,iv:nVd7PX1p5tGtK0iyFGqrZjORan26FSpnYXcAiYoMdOE=,tag:lZlIF12ST6JVhIqtWRkvCg==,type:comment]
-                        #ENC[AES256_GCM,data:k1MevCqEHIUQ09HRt0WqOkTM974oWfFeDQttf1MvXWaPhwhp,iv:kN5Yqsp4zs7J9UKlSJAwNSQ+Nc9bDW2hrFpWCZR25dY=,tag:BWKdXqfTsE/ssX/WBVcRwA==,type:comment]
+                        detachedVolumesFromVolumes: ENC[AES256_GCM,data:1usCjQ==,iv:Am7l2i2043F0Ifw9i342FCmTQd/vB7rXSGPs90+5n7I=,tag:laUcwtPwYtbAGoknFwfMqg==,type:str]
                       mountOptions: []
                       secrets:
                         node-stage-secret:
@@ -157,7 +157,7 @@ sops:
             S0lWSlkreXcyQ2pZVVZsZHZYVXAyMjAK6/b+t9wtQduPuFNBrm9eKBjDBG47co2m
             M/Yc5hrb9DC84vn7lreUBk4cwpwIxd3rnQYyiWf8YnjNV98EnuWKWQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-01T11:40:59Z"
-    mac: ENC[AES256_GCM,data:PZMX9sYTjS8r9izgMCblMKauGJ02Rz1vxcrllONliF72ajLzdNGkW97ybsXJIbENgqcDRvdw0eFPG1N9GJD4r3s6z9NOSA0UgiC7EXUI3/2M9JgDzxvMy3YmW06+66LF+xrmu5fiAtbUgfDe8i2OuR4jbp/QOcmO7BBXMhAMiJ0=,iv:0QKpXkAsjkHF5e1wuWL9qn2xLzig/QhA5fVw9TOl3Kg=,tag:BJjQ9VL2W9ofh2NVYbDgJg==,type:str]
+    lastmodified: "2026-05-10T05:11:51Z"
+    mac: ENC[AES256_GCM,data:ohWw8XQmOQHTLixRxtx/q3cl3wOSBZyLRYpHtnpdjX8LbJ0zutU9HZBYFQCC09e6ps/Ew4g/CrLLU4NMWJD04iDTVVI+VcZapYogLIOkN/5WHKKik7UpOwwoyb+nYwXd9bXkFg7Ayuq4T0Gs15eKNdp5cvjQzHB2gXcjBaIp75I=,iv:tGao7/CeqqHVjJ2pjL7PMR8rZ9DS5seND8QRsAXdYbI=,tag:edFPj0AHb36d/5Pit5OWiQ==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type|project|destination|syncPolicy|repoURL|chart|targetRevision|registry|tag|repository)$
-    version: 3.12.1
+    version: 3.12.2

--- a/kubernetes/infra/velero/values.yaml
+++ b/kubernetes/infra/velero/values.yaml
@@ -49,7 +49,7 @@ schedules:
     template:
       ttl: "360h"
       storageLocation: cloud
-      snapshotMoveData: true
+      defaultVolumesToFsBackup: true
       includedNamespaces:
         - '*'
       excludedNamespaces:


### PR DESCRIPTION
## What

Replace `snapshotMoveData: true` with `defaultVolumesToFsBackup: true` on the weekly-offsite Velero schedule, and enable democratic-CSI `detachedVolumes*` for ZFS send/receive on restores.

## Why

The weekly-offsite backup with `snapshotMoveData: true` creates temporary iSCSI PVCs for each snapshot being moved. With ~30 PVCs, this triggers 120+ PCS CIB modifications in rapid succession, causing:
- Pacemaker election storms and transition aborts
- iSCSI target/LUN resource operation timeouts (10s)
- Pacemaker fatal failure on nas-01 (crashed and stayed down)
- nas-02 UNCLEAN state with repeated failed self-fencing
- 4 media pods stuck in CreateContainerError (I/O errors on iSCSI volumes)

This happened on 2026-05-10 and also on 2026-05-03 (both `PartiallyFailed`).

## Changes

### Velero (`values.yaml`)
- Remove `snapshotMoveData: true` — stops creating temporary iSCSI PVCs
- Add `defaultVolumesToFsBackup: true` — uses kopia file-level backup for offsite data movement (same approach the daily backup uses successfully)

### democratic-CSI (`app-iscsi.sops.yaml`)
- Enable `detachedVolumesFromSnapshots` and `detachedVolumesFromVolumes` — uses ZFS send/receive instead of cloning when creating volumes from snapshots, preventing parent-child clone dependencies that block snapshot deletion

## Additional context

Also promoted the stuck ZFS clone for bazarr (`pvc-80f19998`) that was blocking snapshot deletions. There are 9 orphaned clone zvols from previous Velero data-mover temp volumes that should be cleaned up separately.

Note: democratic-CSI creates new PCS resources with **10s** start/stop timeouts even though existing resources were raised to 30s. This is a separate issue to address in the CSI config.