### PR TITLE
fix(images): refresh stale container digests

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -21,7 +21,7 @@ auto_install = true
 "pipx:ansible-core" = "2.20.4"
 "npm:markdownlint-cli2" = "0.23.1"
 "npm:json5" = "2.2.3"
-"npm:renovate" = "43.270.0"
+"npm:renovate" = { version = "43.270.0", trust_policy_excludes = ["@yarnpkg/libzip@3.2.2"] }
 
 [env]
 # Ensure just uses unstable features (needed for mod support)

--- a/kubernetes/apps/bazarr/values.yaml
+++ b/kubernetes/apps/bazarr/values.yaml
@@ -16,7 +16,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/bazarr
-          tag: 1.5.6@sha256:79fc37491f55c7e24427bcd669bce3df2d7415ca432a47ce9d53cc5988af8411
+          tag: 1.5.6@sha256:80cb090162b47ea1bfb499d742b45a460b282f17ffefa4c01d518a5c8d52a5a4
         probes:
           liveness: &probes
             enabled: true

--- a/kubernetes/apps/mosquitto/values.yaml
+++ b/kubernetes/apps/mosquitto/values.yaml
@@ -8,7 +8,7 @@ controllers:
       init-config:
         image:
           repository: &image docker.io/library/eclipse-mosquitto
-          tag: &tag 2.0.22@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268
+          tag: &tag 2.0.22@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c
         command: ["/bin/sh", "-c"]
         args:
           - |

--- a/kubernetes/apps/paperless/values.yaml
+++ b/kubernetes/apps/paperless/values.yaml
@@ -68,7 +68,7 @@ controllers:
       redis:
         image:
           repository: ghcr.io/valkey-io/valkey
-          tag: 9.0.4@sha256:8436e10bc65c94886a91d4415b6a6dfa9cb5a306fb3b996e5bb67cd2b4854193
+          tag: 9.0.4@sha256:bdf93f670fdb026eba9e2cf852c3fa8062f92e850fa181626c3b056e83ef04cf
         resources:
           requests:
             cpu: 5m


### PR DESCRIPTION
## What

- Refresh the pinned digests for Mosquitto, Bazarr, and Valkey without changing their tags.
- Add the reviewed, exact-version `@yarnpkg/libzip@3.2.2` trust-policy exception from PR #816 for the Renovate tool installation.

## Why

The image tags now resolve to different manifest digests, causing repository-wide image verification to fail. The latest mise runner also blocks CI while installing Renovate because this libzip release lacks provenance evidence. Together, these failures block all Kubernetes PRs.